### PR TITLE
Fix metadata size validation threshold for Discord topics

### DIFF
--- a/packages/discord-integration/src/utils/validators.ts
+++ b/packages/discord-integration/src/utils/validators.ts
@@ -140,5 +140,5 @@ export function isTokenExpired(
 export function isMetadataSizeValid(metadata: unknown): boolean {
   const json = JSON.stringify(metadata)
   const bytes = new TextEncoder().encode(json).length
-  return bytes < 1024
+  return bytes <= 1024
 }


### PR DESCRIPTION
## Summary
- allow room metadata payloads that exactly meet Discord's 1024-byte channel topic limit to pass validation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffd6ba25d083268cfb7731fece76a3