### PR TITLE
Add realtime gateway task breakdown

### DIFF
--- a/.windsurf/rules/specify-rules.md
+++ b/.windsurf/rules/specify-rules.md
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2025-10-13
 - Browser IndexedDB (model caching), CDN-served embeddings (int8 quantized binaries) (012-fix-clip-model-alignment)
 - TypeScript 5.5+, Node.js 20+ (014-discord-gateway-service)
 - N/A (stateless services, in-memory WebSocket registry) (014-discord-gateway-service)
+- TypeScript 5.x (Bun runtime for scripts, Node.js 20 for Start server) + TanStack Start (`@tanstack/react-start`), `ws`, `crossws`, `discord-api-types`, `@repo/discord-gateway`, `zod` (016-realtime-plan)
+- N/A (in-memory event bus and queues only) (016-realtime-plan)
 
 ## Project Structure
 ```
@@ -35,9 +37,9 @@ npm test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNO
 TypeScript 5.x (frontend), Node.js 20+ (build tooling): Follow standard conventions
 
 ## Recent Changes
+- 016-realtime-plan: Added TypeScript 5.x (Bun runtime for scripts, Node.js 20 for Start server) + TanStack Start (`@tanstack/react-start`), `ws`, `crossws`, `discord-api-types`, `@repo/discord-gateway`, `zod`
 - 014-discord-gateway-service: Added TypeScript 5.5+, Node.js 20+
 - 012-fix-clip-model-alignment: Added TypeScript 5.x (ES2022 target), React 19 + @huggingface/transformers 3.7.5, Vite 7.x, TanStack Router, Tailwind CSS 4.x
-- 011-advanced-card-extraction: Added TypeScript 5.x (React/Vite frontend)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/specs/016-realtime-chat-integration/spec.md
+++ b/specs/016-realtime-chat-integration/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Discord Gateway Realtime Communications Platform (TanStack Start ⇄ Gateway ⇄ Discord)
+
+**Feature Branch**: `016-realtime-chat-integration`
+**Created**: 2025-11-01
+**Status**: Draft
+**Input**: User description: "Realtime Chat Integration Spec (TanStack Start ⇄ Gateway ⇄ Discord)"
+
+> **Context Update**: The Spell Coven stack already streams Discord voice signals through bespoke WebSocket hooks (`useVoiceChannelEvents`, `useVoiceChannelMembersFromEvents`) documented in `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md` and related guides. This initiative consolidates those pathways with the chat pipeline and generalizes the Gateway link so that **all** Discord realtime traffic (chat, voice membership, moderation signals, system alerts) flows through a unified Start-side event bus and SSE surface.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stream multi-domain Discord events to web clients (Priority: P1)
+
+An authenticated player opens the Spell Coven web app and immediately begins receiving live Discord activity—text chat, voice membership updates, and system alerts—streamed from the gateway via the `/api/stream` SSE endpoint.
+
+**Why this priority**: Unifying realtime delivery for both the newly scoped chat events and the already shipping voice dropout/member flows removes duplicated sockets (`/api/ws` + `/api/stream`) and positions the app for additional Discord signals without per-feature rewrites.
+
+**Independent Test**: Connect a test browser session, inject representative `messageCreate`, `voice.joined`, and `voice.left` frames from the gateway, and verify they arrive through SSE with trace metadata within the latency budget while existing voice dropout UX (`VoiceDropoutModal`) still triggers correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Start service has a valid link token, **When** it boots, **Then** it establishes and maintains a Gateway WebSocket connection with exponential-backoff reconnect on failure.
+2. **Given** the Gateway sends a `messageCreate`, `messageUpdate`, `voice.joined`, or `voice.left` frame, **When** the Start service receives it, **Then** the same payload is emitted to all subscribed SSE clients within 400ms p95 and includes the original `traceId` and channel/user identifiers used by the existing hooks documented in `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md`.
+3. **Given** a browser client is connected to `/api/stream`, **When** no Discord events occur for 15 seconds, **Then** the client receives a heartbeat comment `: ping` to keep the stream alive.
+4. **Given** a client disconnects from SSE, **When** the underlying stream closes, **Then** the Start service cleans up timers, unsubscribes from the event bus without leaking listeners, and any legacy `/api/ws` bridge used by `useVoiceChannelEvents` becomes optional behind a feature flag.
+
+---
+
+### User Story 2 - Send Discord commands from the browser (Priority: P2)
+
+An authorized player (or moderator) issues Discord commands—sending chat messages, acknowledging voice dropouts, reacting, starting typing indicators—through a unified server function interface backed by the Gateway WebSocket.
+
+**Why this priority**: Bidirectional messaging and control keep the UI in parity with Discord without reintroducing separate pathways for voice and text; refactoring outbound flows now keeps future moderation/admin actions (mute, move member, etc.) within the same abstraction.
+
+**Independent Test**: Call the `sendMessage`, `addReaction`, and `typingStart` server functions with valid inputs, observe the Gateway command payloads on the wire, and confirm Discord receives them while unauthorized users receive 403 responses. Validate that the legacy voice rejoin button continues functioning by dispatching commands through the shared Gateway client instead of bespoke fetch calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with the `chat:write` role, **When** they invoke `sendMessage` with valid data, **Then** the server validates inputs via Zod, assigns `traceId`/`requestId`, forwards a `sendMessage` command over WebSocket, and returns `{ ok: true }` while emitting structured logs consumable by the existing observability tooling described in `docs/IMPLEMENTATION_SUMMARY.md`.
+2. **Given** a user without the `chat:write` role, **When** they call `sendMessage`, **Then** the server function returns 403 without contacting the Gateway.
+3. **Given** the Gateway replies with a `rateLimited` or `error` frame for any command, **When** Start processes it, **Then** the caller receives a 429 or 502 response with a safe error message while the command queue honors retry policies and surfaces rate-limit diagnostics alongside the existing WebSocket voice metrics.
+4. **Given** a user exceeds per-channel or per-user limits (5 msgs / 5s, burst 10), **When** they continue sending, **Then** Start rejects additional calls with 429 until tokens replenish.
+
+---
+
+### User Story 3 - Migrate existing realtime consumers to the unified bus (Priority: P3)
+
+Existing gameplay surfaces—`useVoiceChannelEvents`, `useVoiceChannelMembersFromEvents`, and the `VoiceDropoutModal`—continue to function after the refactor, now consuming the consolidated event bus rather than bespoke WebSocket listeners.
+
+**Why this priority**: Avoid regressions in production voice experiences while delivering the generalized infrastructure. The migration demonstrates backward compatibility and justifies decommissioning the legacy `/api/ws` endpoint.
+
+**Independent Test**: Run the current dropout detection workflow end-to-end (remove a user from a Discord voice channel) while the new Gateway client and SSE route are active, confirm the modal still appears and rejoin actions succeed, and ensure no second WebSocket connection is established in DevTools.
+
+**Acceptance Scenarios**:
+
+1. **Given** the legacy voice hooks subscribe to gateway events, **When** the unified event bus emits `voice.left`, **Then** the modal renders exactly as described in `docs/IMPLEMENTATION_SUMMARY.md` without code duplication.
+2. **Given** the Gateway disconnects mid-command, **When** Start attempts to send `typingStart` or a future voice control command, **Then** the command queue buffers it (up to 1000 entries) and retries after reconnect; if the queue is full, Start responds 503 with a descriptive error and the voice modal surfaces a toast.
+3. **Given** the Gateway emits an `error` frame related to voice or chat operations, **When** Start receives it, **Then** it logs the failure with trace metadata and broadcasts the error to SSE subscribers for operator awareness, allowing existing ops dashboards to alert.
+
+---
+
+### Edge Cases
+
+- What happens when the Gateway WebSocket repeatedly fails to connect? → Start escalates backoff up to 30s, exposes `ws.connected` gauge = 0, logs failures with trace IDs, and continues retrying while rejecting new outbound commands beyond the queue limit with 503 errors. Legacy `/api/ws` consumers detect the feature flag and gracefully fall back to the shared SSE stream.
+- How does system handle malformed frames from the Gateway? → Frames fail schema validation, trigger error logging with trace metadata, and emit an `error` SSE event without crashing the process, mirroring the defensive parsing used in the existing voice hooks.
+- What happens when browser SSE clients rapidly reconnect (e.g., flaky network)? → Start re-registers event listeners per connection, ensures cleanup on close, and enforces heartbeat cadence without exceeding resource limits.
+- How does system handle oversized message payloads (>2000 chars)? → Zod validation fails, and the server function responds with 400 including field-level error details.
+- What happens if LINK_TOKEN authentication fails during WS upgrade? → Start logs the auth failure, surfaces metrics, and retries connection after updating credentials; outbound commands remain queued until a connection is re-established or queue limits are reached.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST maintain a singleton `GatewayWsClient` that authenticates with `Authorization: Bearer ${LINK_TOKEN}` and automatically reconnects with exponential backoff (1s → 30s).
+- **FR-002**: System MUST translate inbound `GatewayEvent` frames—including chat, voice membership, and moderation/system signals defined in existing docs—into `SseEvent` payloads and stream them to all connected browsers via `/api/stream` using proper SSE headers and 15s heartbeats.
+- **FR-003**: System MUST expose `sendMessage`, `addReaction`, `typingStart`, and any migrated voice control operations via `createServerFn` that validate inputs with Zod and enforce role-based authorization.
+- **FR-004**: System MUST attach `traceId`, `sentAt`, and `requestId` metadata to every outbound `GatewayCommand` and log command lifecycle events with latency measurements.
+- **FR-005**: System MUST implement per-user and per-channel token-bucket rate limiting (5 actions per 5 seconds, burst 10) and translate Gateway rate limit signals into 429 responses.
+- **FR-006**: System MUST cap the outbound command queue at 1000 entries, returning 503 when the queue is saturated during Gateway outages.
+- **FR-007**: System MUST emit metrics for message counts, voice membership churn, WebSocket RTT, SSE flush duration, and connection state gauges to support observability targets.
+- **FR-008**: System MUST sanitize user-generated content before logging or re-broadcasting to prevent injection or log forging.
+- **FR-009**: System MUST map validation failures to HTTP 400, authentication failures to 401, authorization failures to 403, Gateway outages to 502, and rate limit breaches to 429.
+- **FR-010**: System MUST ensure secrets such as `LINK_TOKEN` and `DISCORD_BOT_TOKEN` remain server-side and are never exposed to the browser.
+- **FR-011**: System MUST deprecate or wrap the legacy `/api/ws` endpoint so existing hooks adopt the unified event stream without code duplication.
+
+### Key Entities *(include if feature involves data)*
+
+- **GatewayWsClient**: Represents the Start-side WebSocket client responsible for connecting to the Gateway, queueing commands, handling reconnect logic, and dispatching `GatewayEvent` frames onto the event bus while replacing bespoke sockets referenced in `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md`.
+- **EventBus**: In-memory publish/subscribe utility that Start uses to fan out `GatewayEvent` data to SSE streams, voice dropout handlers, and other server consumers.
+- **SseClientSession**: Logical representation of each browser connection to `/api/stream`, including heartbeat timer management and unsubscribe callbacks for cleanup.
+- **CommandEnvelope**: Structured payload for outbound operations containing `GatewayCommand` data, associated `requestId`, `traceId`, enqueue timestamps, and retry counters for backoff handling.
+- **UserContext**: Derived authentication object capturing `userId` and role assignments used to evaluate authorization rules for server functions.
+- **LegacyBridgeAdapter**: Temporary abstraction that allows existing WebSocket hooks to consume the unified SSE/event bus stream until those clients are refactored, preventing regressions during rollout.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 95th percentile latency from Gateway event receipt to SSE delivery remains ≤ 400ms during local integration tests for both chat and voice membership events.
+- **SC-002**: 95% of outbound commands reach the Gateway within 100ms when the WebSocket link is healthy.
+- **SC-003**: Unauthorized `sendMessage` attempts consistently return HTTP 403 with zero Gateway transmissions in 100% of test cases.
+- **SC-004**: Start service automatically re-establishes the Gateway WebSocket within 30 seconds of an outage in 99% of simulated failures without manual intervention.
+- **SC-005**: Load testing with 100 concurrent clients sending 10 mixed commands (chat + voice control) per second for 60 seconds yields ≤ 1% error responses and ≤ 800ms SSE delivery p95.
+- **SC-006**: All command and event logs include a `traceId`, enabling end-to-end correlation during observability audits and mapping back to the existing dropout metrics dashboard.
+- **SC-007**: After migration, DevTools shows a single persistent SSE connection for realtime Discord data and no redundant `/api/ws` connection when navigating GameRoom flows.

--- a/specs/016-realtime-plan/contracts/openapi.yaml
+++ b/specs/016-realtime-plan/contracts/openapi.yaml
@@ -1,0 +1,263 @@
+openapi: 3.1.0
+info:
+  title: Discord Gateway Realtime Communications API
+  version: 1.0.0
+  description: |
+    Contracts for TanStack Start server functions and SSE endpoint that proxy Discord Gateway commands/events.
+servers:
+  - url: https://spellcoven.example.com
+paths:
+  /api/stream:
+    get:
+      summary: Subscribe to realtime Discord events via Server-Sent Events
+      operationId: subscribeSse
+      responses:
+        '200':
+          description: Stream of `SseEvent` frames
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/SseEvent'
+      security:
+        - sessionAuth: []
+  /api/send-message:
+    post:
+      summary: Send a Discord chat message through the gateway
+      operationId: sendMessage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendMessageInput'
+      responses:
+        '200':
+          description: Acknowledgement of enqueue success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/AuthError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitError'
+        '502':
+          $ref: '#/components/responses/GatewayError'
+      security:
+        - sessionAuth: []
+  /api/add-reaction:
+    post:
+      summary: Add a reaction to a Discord message
+      operationId: addReaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddReactionInput'
+      responses:
+        '200':
+          description: Reaction command accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/AuthError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitError' }
+        '502': { $ref: '#/components/responses/GatewayError' }
+      security:
+        - sessionAuth: []
+  /api/typing-start:
+    post:
+      summary: Trigger Discord typing indicator
+      operationId: typingStart
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TypingStartInput'
+      responses:
+        '200':
+          description: Typing command accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/AuthError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitError' }
+        '502': { $ref: '#/components/responses/GatewayError' }
+      security:
+        - sessionAuth: []
+components:
+  securitySchemes:
+    sessionAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    OkResponse:
+      type: object
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+          const: true
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+    ValidationIssue:
+      type: object
+      required: [path, message]
+      properties:
+        path:
+          type: array
+          items:
+            type: string
+        message:
+          type: string
+    SendMessageInput:
+      type: object
+      required: [channelId, content]
+      properties:
+        channelId:
+          type: string
+          minLength: 1
+        content:
+          type: string
+          minLength: 1
+          maxLength: 2000
+    AddReactionInput:
+      type: object
+      required: [channelId, messageId, emoji]
+      properties:
+        channelId:
+          type: string
+          minLength: 1
+        messageId:
+          type: string
+          minLength: 1
+        emoji:
+          type: string
+          minLength: 1
+          description: Unicode emoji or Discord custom emoji syntax
+    TypingStartInput:
+      type: object
+      required: [channelId]
+      properties:
+        channelId:
+          type: string
+          minLength: 1
+    TraceMeta:
+      type: object
+      required: [traceId, sentAt]
+      properties:
+        traceId:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+    GatewayEvent:
+      type: object
+      required: [version, type, data]
+      properties:
+        version:
+          type: string
+          example: '1.0'
+        type:
+          type: string
+          enum: [ready, messageCreate, messageUpdate, messageDelete, voice.joined, voice.left, error]
+        data:
+          type: object
+          additionalProperties: true
+        meta:
+          $ref: '#/components/schemas/TraceMeta'
+    GatewayCommand:
+      type: object
+      required: [version, type, data]
+      properties:
+        version:
+          type: string
+          example: '1.0'
+        type:
+          type: string
+          enum: [sendMessage, addReaction, typingStart]
+        data:
+          type: object
+          additionalProperties: true
+        meta:
+          $ref: '#/components/schemas/TraceMeta'
+    SseEvent:
+      type: object
+      required: [version, event, data]
+      properties:
+        version:
+          type: string
+          example: '1.0'
+        event:
+          type: string
+          enum: [ready, messageCreate, messageUpdate, messageDelete, voice.joined, voice.left, error]
+        data:
+          type: object
+          additionalProperties: true
+  responses:
+    ValidationError:
+      description: Request payload failed validation
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ErrorResponse'
+              - type: object
+                properties:
+                  issues:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationIssue'
+    AuthError:
+      description: Caller not authenticated
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    ForbiddenError:
+      description: Caller lacks `chat:write` role or channel permission
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    RateLimitError:
+      description: Per-user or gateway rate limit exceeded
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ErrorResponse'
+              - type: object
+                properties:
+                  retryAfterMs:
+                    type: integer
+                    minimum: 0
+    GatewayError:
+      description: Gateway unavailable or returned error frame
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'

--- a/specs/016-realtime-plan/data-model.md
+++ b/specs/016-realtime-plan/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Discord Gateway Realtime Communications Platform
+
+## GatewayWsClient
+- **Purpose**: Maintain a singleton WebSocket connection from TanStack Start to the gateway service.
+- **Fields**:
+  - `state: 'idle' | 'connecting' | 'connected' | 'reconnecting'`
+  - `ws: WebSocket | null`
+  - `eventBus: EventBus<GatewayEvent>`
+  - `commandQueue: CommandQueue`
+  - `pendingPings: Map<string, number>` (traceId → sent timestamp for RTT metrics)
+  - `reconnectTimer: NodeJS.Timeout | null`
+  - `listeners: Set<(event: GatewayEvent) => void>` (delegates to `eventBus`)
+- **Relationships**:
+  - Publishes to `EventBus`
+  - Consumed by SSE route, server functions, legacy adapters
+- **Validation/Constraints**:
+  - Only one active `WebSocket`
+  - Requires `LINK_TOKEN` env var; fails fast if missing
+  - Reconnect backoff 1s → 30s with jitter
+
+## EventBus<T>
+- **Purpose**: Fan out gateway events across server modules.
+- **Fields**:
+  - `subscribers: Set<(event: T) => void>`
+- **Relationships**:
+  - Receives events from `GatewayWsClient`
+  - SSE stream and legacy bridge subscribe
+- **Validation/Constraints**:
+  - Synchronous dispatch; wrap handler exceptions to avoid breaking publisher
+
+## CommandEnvelope
+- **Purpose**: Track outbound command lifecycle for retries and metrics.
+- **Fields**:
+  - `command: GatewayCommand`
+  - `requestId: string`
+  - `traceId: string`
+  - `enqueuedAt: number`
+  - `attempts: number`
+  - `nextAttemptAt: number`
+- **Relationships**:
+  - Stored in `CommandQueue`
+  - Dequeued by `GatewayWsClient` when connection available
+- **Validation/Constraints**:
+  - Queue size capped at 1000
+  - Attempts escalate backoff up to 30 000 ms
+
+## CommandQueue
+- **Purpose**: Buffer commands while gateway unavailable and enforce rate limits.
+- **Fields**:
+  - `items: CommandEnvelope[]`
+  - `timer: NodeJS.Timeout | null`
+- **Relationships**:
+  - Managed by `GatewayWsClient`
+- **Validation/Constraints**:
+  - FIFO ordering maintained
+  - Emits 503 when full
+
+## RateLimiterState
+- **Purpose**: Enforce per-user and per-channel quotas in server functions.
+- **Fields**:
+  - `buckets: Map<string, { tokens: number; updatedAt: number }>` (key format `${userId}:${channelId}`)
+- **Relationships**:
+  - Called by `sendMessage`, `addReaction`, `typingStart`
+- **Validation/Constraints**:
+  - Burst = 10 tokens, refill 5 tokens per 5 000 ms
+  - Rejects when tokens exhausted → 429
+
+## SseClientSession
+- **Purpose**: Track SSE connection lifecycle and cleanup.
+- **Fields**:
+  - `id: string`
+  - `controller: ReadableStreamDefaultController<string>`
+  - `unsub: () => void`
+  - `heartbeatTimer: NodeJS.Timeout`
+- **Relationships**:
+  - Created per `/api/stream` request
+  - Subscribes to `EventBus`
+- **Validation/Constraints**:
+  - Heartbeat every 15 000 ms as comment
+  - Cleanup unsubscribes and clears timer on close
+
+## LegacyBridgeAdapter
+- **Purpose**: Feed existing `/api/ws` endpoint and React voice hooks using the new event bus.
+- **Fields**:
+  - `enabled: boolean` (feature flag)
+  - `relay: (event: GatewayEvent) => void`
+- **Relationships**:
+  - Subscribes to `EventBus`
+  - Uses `wsManager.broadcastToGuild` when WebSocket fallback active
+- **Validation/Constraints**:
+  - Only attaches when `/api/ws` feature flag on
+  - Filters to voice events expected by current hooks
+
+## LogRecord
+- **Purpose**: Provide consistent observability payload for gateway operations.
+- **Fields**:
+  - `traceId: string`
+  - `event: string`
+  - `level: 'info' | 'warn' | 'error'`
+  - `latencyMs?: number`
+  - `metadata: Record<string, string | number | boolean>`
+- **Relationships**:
+  - Produced by command dispatch, event receipt, and error handling
+- **Validation/Constraints**:
+  - Must include `traceId` for correlation per spec

--- a/specs/016-realtime-plan/plan.md
+++ b/specs/016-realtime-plan/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: Discord Gateway Realtime Communications Platform
+
+**Branch**: `016-realtime-plan` | **Date**: 2025-11-01 | **Spec**: [`/specs/016-realtime-chat-integration/spec.md`](../016-realtime-chat-integration/spec.md)
+**Input**: Feature specification from `/specs/016-realtime-chat-integration/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Unify the TanStack Start realtime stack so that a single `GatewayWsClient` maintains the Discord Gateway link, distributes all inbound frames across an in-memory event bus, and exposes them through `/api/stream` SSE while routing outbound commands through `createServerFn` handlers with shared rate limiting, tracing, and backpressure controls. The plan layers on top of the existing voice dropout WebSocket implementation, migrating it to the shared gateway adapter without regressing current voice workflows.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Bun runtime for scripts, Node.js 20 for Start server)
+**Primary Dependencies**: TanStack Start (`@tanstack/react-start`), `ws`, `crossws`, `discord-api-types`, `@repo/discord-gateway`, `zod`
+**Storage**: N/A (in-memory event bus and queues only)
+**Testing**: Vitest for unit tests, Playwright for browser contract checks where required
+**Target Platform**: TanStack Start server on Node.js 20, browser clients consuming SSE
+**Project Type**: Web application (server + client within `apps/web`)
+**Performance Goals**: ≤400 ms p95 Gateway→SSE latency, ≤100 ms p95 command dispatch, reconnect within 30 s, sustain 100 msgs/s baseline with 500 msgs/s bursts
+**Constraints**: Keep secrets server-side (`LINK_TOKEN`, `DISCORD_BOT_TOKEN`), cap outbound queue at 1000 entries, reuse existing voice dropout UX, SSE heartbeat every 15 s
+**Scale/Scope**: Single Discord guild deployment, hundreds of concurrent SSE clients, reuse across chat, voice membership, and moderation events
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Browser-First Architecture**: ✅ Social features (Discord connectivity) are permitted server-side; plan keeps gameplay features client-first while ensuring realtime Discord integration remains optional for offline play.
+- **Data Contract Discipline**: ⚠️ Requires explicit versioned contracts for Gateway frames and SSE payloads—current voice events lack version fields. Address during Phase 1 by versioning TypeScript types and documenting schemas.
+- **User-Centric Prioritization**: ✅ Plan aligns with user stories prioritizing realtime feedback and continuity of voice dropout protections.
+- **Specification-Driven Development**: ✅ Working directly from spec and producing plan artifacts.
+- **Monorepo Package Isolation**: ✅ Changes confined to `apps/web` server/client boundary and shared `packages/discord-gateway` types without breaking isolation.
+- **Performance Through Optimization, Not Complexity**: ✅ Focus on consolidating sockets and reducing duplication rather than adding extra infrastructure.
+- **Open Source and Community-Driven**: ✅ Documentation updates (quickstart, contracts) ensure contributors can adopt unified gateway path.
+
+**Gate Result**: ⚠️ Conditional approval pending addition of version metadata to contracts in Phase 1.
+
+*Post-Phase 1 Update*: ✅ Versioned envelopes (`version: "1.0"`) documented in `contracts/openapi.yaml`; gate satisfied.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```
+apps/web/
+├── src/
+│   ├── server/
+│   │   ├── gateway/
+│   │   │   ├── gateway-ws.client.ts      # new singleton GatewayWsClient implementation
+│   │   │   ├── event-bus.ts              # in-memory event bus abstraction
+│   │   │   ├── command-queue.ts          # outbound queue + rate limiting helpers
+│   │   │   └── sse-router.server.ts      # `/api/stream` handler
+│   │   ├── actions/
+│   │   │   ├── send-message.ts
+│   │   │   ├── add-reaction.ts
+│   │   │   └── typing-start.ts
+│   │   ├── legacy/
+│   │   │   └── voice-bridge.ts           # adapter feeding existing voice hooks from bus
+│   │   └── metrics/
+│   │       └── gateway-metrics.ts        # counters, histograms, gauges
+│   ├── hooks/
+│   │   └── useVoiceChannelEvents.ts      # updated to consume unified bus/SSE
+│   └── routes/
+│       └── api/
+│           ├── stream.ts                 # SSE endpoint (imports from gateway)
+│           └── internal/events.ts        # deprecated wrapper, forwards to bus when enabled
+└── tests/
+    ├── server/gateway-ws.test.ts
+    └── integration/realtime-bridge.test.ts
+```
+
+**Structure Decision**: Extend existing `apps/web/src/server` hierarchy with a dedicated `gateway/` module housing the singleton client, event bus, command queue, and SSE route. Update existing hooks within `apps/web/src/hooks` to consume the new event bus through an adapter in `server/legacy`. Add focused server and integration tests under `apps/web/tests` to validate contract handling and migration safety.
+
+## Complexity Tracking
+
+No constitution violations require additional justification at this stage.

--- a/specs/016-realtime-plan/quickstart.md
+++ b/specs/016-realtime-plan/quickstart.md
@@ -1,0 +1,43 @@
+# Quickstart: Discord Gateway Realtime Communications Platform
+
+1. **Install dependencies**
+   ```bash
+   pnpm install
+   pnpm --filter @repo/web build
+   ```
+
+2. **Set required environment variables**
+   - `GATEWAY_WS_URL` → wss endpoint exposed by gateway service
+   - `LINK_TOKEN` → shared bearer token for Start ↔ Gateway authentication
+   - `HUB_SECRET` → existing HMAC secret for `/api/internal/events` fallback
+   - `VITE_DISCORD_GUILD_ID` → guild scope used by legacy voice bridge
+
+3. **Run TanStack Start dev server**
+   ```bash
+   pnpm --filter @repo/web dev
+   ```
+   - This starts the Start server, initializes the `GatewayWsClient`, and exposes `/api/stream` SSE.
+
+4. **Verify SSE stream**
+   ```bash
+   curl -H "Authorization: Bearer <session-token>" \
+        -N http://localhost:3000/api/stream
+   ```
+   - Expect `: ping` heartbeats every 15 s and JSON events when the gateway pushes frames.
+
+5. **Send a test command**
+   ```bash
+   curl -X POST http://localhost:3000/api/send-message \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer <session-token>" \
+        -d '{"channelId":"123","content":"Hello Gateway"}'
+   ```
+   - Response should be `{ "ok": true }` when rate limits permit.
+
+6. **Observe logs & metrics**
+   - Server logs include `traceId`, command type, and latency.
+   - Metrics published via `gateway-metrics.ts` feed existing observability pipeline.
+
+7. **Legacy bridge toggle**
+   - Set feature flag `ENABLE_WS_BRIDGE=true` (e.g., via environment) to keep `/api/ws` active while migrating hooks.
+   - Disable after confirming React hooks consume SSE directly.

--- a/specs/016-realtime-plan/research.md
+++ b/specs/016-realtime-plan/research.md
@@ -1,0 +1,43 @@
+# Research Findings: Discord Gateway Realtime Communications Platform
+
+## Decision 1: Versioned Event Envelopes (`v1.0`)
+- **Decision**: Introduce a `version` field on all inbound `GatewayEvent` and outbound `SseEvent`/`GatewayCommand` envelopes with initial value `"1.0"`, retaining type/data/meta structure from the spec.
+- **Rationale**: Aligns with the constitution's Data Contract Discipline (version metadata) and enables future additions (e.g., voice moderation events) without breaking consumers.
+- **Alternatives considered**:
+  - *Implicit versioning via TypeScript types*: Rejected because runtime consumers (SSE clients, legacy WebSocket bridge) require explicit version negotiation per constitution.
+  - *Semantic version per event type*: Overkill for current scope; envelope-level version provides consistent upgrade path.
+
+## Decision 2: Singleton Gateway Client with Lazy Connect
+- **Decision**: Implement `GatewayWsClient` as a module-level singleton that lazily connects on first `start()` call and reuses the same `ws` instance across requests using Node's global scope.
+- **Rationale**: TanStack Start server routes run in a long-lived Node process; lazy initialization avoids connection attempts during build and ensures we only connect when SSE/server functions need it. Mirrors existing voice WebSocket manager's singleton pattern.
+- **Alternatives considered**:
+  - *Per-request instantiation*: Violates latency/queue requirements and would amplify Discord rate limits.
+  - *Dependency injection container*: Unnecessary complexity compared to module singleton.
+
+## Decision 3: In-Memory Event Bus via `Set` Subscribers
+- **Decision**: Build a lightweight event bus that keeps a `Set` of subscriber callbacks and synchronously invokes them for each `GatewayEvent`.
+- **Rationale**: Avoids pulling additional dependencies; current voice hooks rely on synchronous dispatch for minimal latency. Simple `Set` ensures O(n) fan-out while enabling efficient unsubscribe.
+- **Alternatives considered**:
+  - *Node `EventEmitter`*: Brings listener leak warnings and string-based channels we don't need.
+  - *RxJS/observable*: Adds heavy dependency for little benefit.
+
+## Decision 4: Token Bucket Rate Limiter per `(userId, channelId)`
+- **Decision**: Store limiter state in a nested `Map` keyed by user and channel, replenishing tokens every 5 seconds via timestamp math.
+- **Rationale**: Satisfies spec requirement (5 msgs per 5s, burst 10) without background timers. Similar approach already used in `packages/discord-gateway` heartbeat/backoff handling.
+- **Alternatives considered**:
+  - *External store (Redis)*: Violates constraint against adding new infrastructure.
+  - *Leaky bucket queue*: More complex and unnecessary for the given thresholds.
+
+## Decision 5: Legacy Voice Bridge via Server-Sent Events
+- **Decision**: Maintain `/api/ws` temporarily by wiring it to consume the new event bus, but gate it behind a feature flag so React hooks transition to consuming SSE (and eventually can drop the WebSocket path).
+- **Rationale**: Ensures backwards compatibility per spec while allowing incremental migration. Keeps the modal working even if SSE client work lags.
+- **Alternatives considered**:
+  - *Immediate removal of `/api/ws`*: Risky; existing hooks expect it today.
+  - *Dual publish from Gateway client*: Would duplicate logic and complicate cleanup; better to funnel through one bus and adapt at edges.
+
+## Decision 6: Command Queue with Exponential Backoff
+- **Decision**: Maintain a FIFO queue capped at 1000 entries storing command + metadata. If gateway disconnected, enqueue and schedule retries with decorrelated jitter (base 1000 ms, multiplier 2, max 30 s).
+- **Rationale**: Meets spec's backpressure requirements and leverages existing reconnect targets (1 s → 30 s). Decorrelated jitter prevents thundering herd when reconnecting multiple commands.
+- **Alternatives considered**:
+  - *Immediate rejection when disconnected*: Fails acceptance scenario requiring automatic retry.
+  - *Promise-based queue with await*: Harder to integrate with SSE/event bus; simple timer loop is sufficient.

--- a/specs/016-realtime-plan/spec.md
+++ b/specs/016-realtime-plan/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Discord Gateway Realtime Communications Platform (TanStack Start ⇄ Gateway ⇄ Discord)
+
+**Feature Branch**: `016-realtime-chat-integration`
+**Created**: 2025-11-01
+**Status**: Draft
+**Input**: User description: "Realtime Chat Integration Spec (TanStack Start ⇄ Gateway ⇄ Discord)"
+
+> **Context Update**: The Spell Coven stack already streams Discord voice signals through bespoke WebSocket hooks (`useVoiceChannelEvents`, `useVoiceChannelMembersFromEvents`) documented in `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md` and related guides. This initiative consolidates those pathways with the chat pipeline and generalizes the Gateway link so that **all** Discord realtime traffic (chat, voice membership, moderation signals, system alerts) flows through a unified Start-side event bus and SSE surface.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stream multi-domain Discord events to web clients (Priority: P1)
+
+An authenticated player opens the Spell Coven web app and immediately begins receiving live Discord activity—text chat, voice membership updates, and system alerts—streamed from the gateway via the `/api/stream` SSE endpoint.
+
+**Why this priority**: Unifying realtime delivery for both the newly scoped chat events and the already shipping voice dropout/member flows removes duplicated sockets (`/api/ws` + `/api/stream`) and positions the app for additional Discord signals without per-feature rewrites.
+
+**Independent Test**: Connect a test browser session, inject representative `messageCreate`, `voice.joined`, and `voice.left` frames from the gateway, and verify they arrive through SSE with trace metadata within the latency budget while existing voice dropout UX (`VoiceDropoutModal`) still triggers correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Start service has a valid link token, **When** it boots, **Then** it establishes and maintains a Gateway WebSocket connection with exponential-backoff reconnect on failure.
+2. **Given** the Gateway sends a `messageCreate`, `messageUpdate`, `voice.joined`, or `voice.left` frame, **When** the Start service receives it, **Then** the same payload is emitted to all subscribed SSE clients within 400ms p95 and includes the original `traceId` and channel/user identifiers used by the existing hooks documented in `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md`.
+3. **Given** a browser client is connected to `/api/stream`, **When** no Discord events occur for 15 seconds, **Then** the client receives a heartbeat comment `: ping` to keep the stream alive.
+4. **Given** a client disconnects from SSE, **When** the underlying stream closes, **Then** the Start service cleans up timers, unsubscribes from the event bus without leaking listeners, and any legacy `/api/ws` bridge used by `useVoiceChannelEvents` becomes optional behind a feature flag.
+
+---
+
+### User Story 2 - Send Discord commands from the browser (Priority: P2)
+
+An authorized player (or moderator) issues Discord commands—sending chat messages, acknowledging voice dropouts, reacting, starting typing indicators—through a unified server function interface backed by the Gateway WebSocket.
+
+**Why this priority**: Bidirectional messaging and control keep the UI in parity with Discord without reintroducing separate pathways for voice and text; refactoring outbound flows now keeps future moderation/admin actions (mute, move member, etc.) within the same abstraction.
+
+**Independent Test**: Call the `sendMessage`, `addReaction`, and `typingStart` server functions with valid inputs, observe the Gateway command payloads on the wire, and confirm Discord receives them while unauthorized users receive 403 responses. Validate that the legacy voice rejoin button continues functioning by dispatching commands through the shared Gateway client instead of bespoke fetch calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with the `chat:write` role, **When** they invoke `sendMessage` with valid data, **Then** the server validates inputs via Zod, assigns `traceId`/`requestId`, forwards a `sendMessage` command over WebSocket, and returns `{ ok: true }` while emitting structured logs consumable by the existing observability tooling described in `docs/IMPLEMENTATION_SUMMARY.md`.
+2. **Given** a user without the `chat:write` role, **When** they call `sendMessage`, **Then** the server function returns 403 without contacting the Gateway.
+3. **Given** the Gateway replies with a `rateLimited` or `error` frame for any command, **When** Start processes it, **Then** the caller receives a 429 or 502 response with a safe error message while the command queue honors retry policies and surfaces rate-limit diagnostics alongside the existing WebSocket voice metrics.
+4. **Given** a user exceeds per-channel or per-user limits (5 msgs / 5s, burst 10), **When** they continue sending, **Then** Start rejects additional calls with 429 until tokens replenish.
+
+---
+
+### User Story 3 - Migrate existing realtime consumers to the unified bus (Priority: P3)
+
+Existing gameplay surfaces—`useVoiceChannelEvents`, `useVoiceChannelMembersFromEvents`, and the `VoiceDropoutModal`—continue to function after the refactor, now consuming the consolidated event bus rather than bespoke WebSocket listeners.
+
+**Why this priority**: Avoid regressions in production voice experiences while delivering the generalized infrastructure. The migration demonstrates backward compatibility and justifies decommissioning the legacy `/api/ws` endpoint.
+
+**Independent Test**: Run the current dropout detection workflow end-to-end (remove a user from a Discord voice channel) while the new Gateway client and SSE route are active, confirm the modal still appears and rejoin actions succeed, and ensure no second WebSocket connection is established in DevTools.
+
+**Acceptance Scenarios**:
+
+1. **Given** the legacy voice hooks subscribe to gateway events, **When** the unified event bus emits `voice.left`, **Then** the modal renders exactly as described in `docs/IMPLEMENTATION_SUMMARY.md` without code duplication.
+2. **Given** the Gateway disconnects mid-command, **When** Start attempts to send `typingStart` or a future voice control command, **Then** the command queue buffers it (up to 1000 entries) and retries after reconnect; if the queue is full, Start responds 503 with a descriptive error and the voice modal surfaces a toast.
+3. **Given** the Gateway emits an `error` frame related to voice or chat operations, **When** Start receives it, **Then** it logs the failure with trace metadata and broadcasts the error to SSE subscribers for operator awareness, allowing existing ops dashboards to alert.
+
+---
+
+### Edge Cases
+
+- What happens when the Gateway WebSocket repeatedly fails to connect? → Start escalates backoff up to 30s, exposes `ws.connected` gauge = 0, logs failures with trace IDs, and continues retrying while rejecting new outbound commands beyond the queue limit with 503 errors. Legacy `/api/ws` consumers detect the feature flag and gracefully fall back to the shared SSE stream.
+- How does system handle malformed frames from the Gateway? → Frames fail schema validation, trigger error logging with trace metadata, and emit an `error` SSE event without crashing the process, mirroring the defensive parsing used in the existing voice hooks.
+- What happens when browser SSE clients rapidly reconnect (e.g., flaky network)? → Start re-registers event listeners per connection, ensures cleanup on close, and enforces heartbeat cadence without exceeding resource limits.
+- How does system handle oversized message payloads (>2000 chars)? → Zod validation fails, and the server function responds with 400 including field-level error details.
+- What happens if LINK_TOKEN authentication fails during WS upgrade? → Start logs the auth failure, surfaces metrics, and retries connection after updating credentials; outbound commands remain queued until a connection is re-established or queue limits are reached.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST maintain a singleton `GatewayWsClient` that authenticates with `Authorization: Bearer ${LINK_TOKEN}` and automatically reconnects with exponential backoff (1s → 30s).
+- **FR-002**: System MUST translate inbound `GatewayEvent` frames—including chat, voice membership, and moderation/system signals defined in existing docs—into `SseEvent` payloads and stream them to all connected browsers via `/api/stream` using proper SSE headers and 15s heartbeats.
+- **FR-003**: System MUST expose `sendMessage`, `addReaction`, `typingStart`, and any migrated voice control operations via `createServerFn` that validate inputs with Zod and enforce role-based authorization.
+- **FR-004**: System MUST attach `traceId`, `sentAt`, and `requestId` metadata to every outbound `GatewayCommand` and log command lifecycle events with latency measurements.
+- **FR-005**: System MUST implement per-user and per-channel token-bucket rate limiting (5 actions per 5 seconds, burst 10) and translate Gateway rate limit signals into 429 responses.
+- **FR-006**: System MUST cap the outbound command queue at 1000 entries, returning 503 when the queue is saturated during Gateway outages.
+- **FR-007**: System MUST emit metrics for message counts, voice membership churn, WebSocket RTT, SSE flush duration, and connection state gauges to support observability targets.
+- **FR-008**: System MUST sanitize user-generated content before logging or re-broadcasting to prevent injection or log forging.
+- **FR-009**: System MUST map validation failures to HTTP 400, authentication failures to 401, authorization failures to 403, Gateway outages to 502, and rate limit breaches to 429.
+- **FR-010**: System MUST ensure secrets such as `LINK_TOKEN` and `DISCORD_BOT_TOKEN` remain server-side and are never exposed to the browser.
+- **FR-011**: System MUST deprecate or wrap the legacy `/api/ws` endpoint so existing hooks adopt the unified event stream without code duplication.
+
+### Key Entities *(include if feature involves data)*
+
+- **GatewayWsClient**: Represents the Start-side WebSocket client responsible for connecting to the Gateway, queueing commands, handling reconnect logic, and dispatching `GatewayEvent` frames onto the event bus while replacing bespoke sockets referenced in `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md`.
+- **EventBus**: In-memory publish/subscribe utility that Start uses to fan out `GatewayEvent` data to SSE streams, voice dropout handlers, and other server consumers.
+- **SseClientSession**: Logical representation of each browser connection to `/api/stream`, including heartbeat timer management and unsubscribe callbacks for cleanup.
+- **CommandEnvelope**: Structured payload for outbound operations containing `GatewayCommand` data, associated `requestId`, `traceId`, enqueue timestamps, and retry counters for backoff handling.
+- **UserContext**: Derived authentication object capturing `userId` and role assignments used to evaluate authorization rules for server functions.
+- **LegacyBridgeAdapter**: Temporary abstraction that allows existing WebSocket hooks to consume the unified SSE/event bus stream until those clients are refactored, preventing regressions during rollout.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 95th percentile latency from Gateway event receipt to SSE delivery remains ≤ 400ms during local integration tests for both chat and voice membership events.
+- **SC-002**: 95% of outbound commands reach the Gateway within 100ms when the WebSocket link is healthy.
+- **SC-003**: Unauthorized `sendMessage` attempts consistently return HTTP 403 with zero Gateway transmissions in 100% of test cases.
+- **SC-004**: Start service automatically re-establishes the Gateway WebSocket within 30 seconds of an outage in 99% of simulated failures without manual intervention.
+- **SC-005**: Load testing with 100 concurrent clients sending 10 mixed commands (chat + voice control) per second for 60 seconds yields ≤ 1% error responses and ≤ 800ms SSE delivery p95.
+- **SC-006**: All command and event logs include a `traceId`, enabling end-to-end correlation during observability audits and mapping back to the existing dropout metrics dashboard.
+- **SC-007**: After migration, DevTools shows a single persistent SSE connection for realtime Discord data and no redundant `/api/ws` connection when navigating GameRoom flows.

--- a/specs/016-realtime-plan/tasks.md
+++ b/specs/016-realtime-plan/tasks.md
@@ -1,0 +1,181 @@
+# Tasks: Discord Gateway Realtime Communications Platform
+
+**Input**: Design documents from `/specs/016-realtime-plan/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Add the tests called out per user story. Focus on Vitest for server units and integration harnesses under `apps/web/tests`.
+
+**Organization**: Tasks are grouped by user story so each increment is independently implementable and verifiable.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+- Backend code lives in `apps/web/src/server`
+- Frontend React hooks live in `apps/web/src/hooks`
+- API routes live in `apps/web/src/routes`
+- Shared gateway types reside in `packages/discord-gateway`
+- Tests live in `apps/web/tests`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare environment configuration and testing scaffolding used by all stories
+
+- [ ] T001 Update `.env.example` with `GATEWAY_WS_URL`, `LINK_TOKEN`, and `ENABLE_WS_BRIDGE` placeholders for the realtime gateway secrets
+- [ ] T002 Create `apps/web/tests/server/README.md` and `apps/web/tests/integration/README.md` to describe new realtime test suites and ensure directories exist
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core gateway primitives that must exist before delivering story-specific behavior
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Update `packages/discord-gateway/src/types.ts` with versioned `TraceMeta`, `GatewayEvent`, and `GatewayCommand` contracts and sanitize helpers
+- [ ] T004 Export the new realtime contracts from `packages/discord-gateway/src/index.ts` and `packages/discord-gateway/types/index.d.ts`
+- [ ] T005 Add `apps/web/src/server/gateway/event-bus.ts` implementing the in-memory `EventBus<GatewayEvent>` with safe subscriber teardown
+- [ ] T006 Add `apps/web/src/server/gateway/command-queue.ts` encapsulating the capped retry queue with jitter backoff controls
+- [ ] T007 Add `apps/web/src/server/gateway/config.ts` to parse `GATEWAY_WS_URL`, `LINK_TOKEN`, and feature flags with descriptive errors
+- [ ] T008 Add `apps/web/src/server/metrics/gateway-metrics.ts` exposing counters, histograms, and gauges for gateway health
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Stream multi-domain Discord events to web clients (Priority: P1) 🎯 MVP
+
+**Goal**: Unify inbound gateway traffic through a singleton client and broadcast via `/api/stream` SSE with observability guarantees
+
+**Independent Test**: Connect a browser to `/api/stream`, inject `messageCreate`, `voice.joined`, and `voice.left` frames via the gateway mock, and verify SSE delivers each event with trace metadata and heartbeat cadence within latency targets
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Implement `apps/web/src/server/gateway/gateway-ws.client.ts` to lazily connect, reconnect with backoff, fan out events, and emit logs/metrics
+- [ ] T010 [P] [US1] Implement `apps/web/src/server/gateway/sse-router.server.ts` to translate bus events into SSE frames with 15s heartbeats
+- [ ] T011 [US1] Add `apps/web/src/routes/api/stream.ts` to wire the SSE handler into TanStack Start and ensure `gateway.start()` is invoked
+- [ ] T012 [US1] Refactor `apps/web/src/server/init/start-ws.server.ts` to bootstrap the singleton gateway client instead of the legacy Discord connector
+- [ ] T013 [US1] Replace `apps/web/src/server/init/discord-gateway-init.ts` with a facade that delegates lifecycle controls to the new `GatewayWsClient`
+- [ ] T014 [US1] Update `apps/web/src/server/internal-events-handler.server.ts` to emit incoming hub fallbacks onto the event bus with structured logging
+- [ ] T015 [US1] Add Vitest coverage in `apps/web/tests/server/gateway-ws.test.ts` for reconnect logic, queue overflow, and event bus fan-out
+- [ ] T016 [US1] Add integration test `apps/web/tests/integration/realtime-bridge.test.ts` that streams mock gateway events and asserts SSE delivery + metrics gauges
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Send Discord commands from the browser (Priority: P2)
+
+**Goal**: Provide rate-limited, authorized server functions that enqueue gateway commands with traceability
+
+**Independent Test**: Call the `sendMessage`, `addReaction`, and `typingStart` server functions under varying auth/rate-limit conditions and verify Gateway commands, logs, and HTTP responses align with the contract
+
+### Implementation for User Story 2
+
+- [ ] T017 [US2] Implement `apps/web/src/server/gateway/rate-limiter.ts` providing per-user and per-channel token buckets
+- [ ] T018 [P] [US2] Add `apps/web/src/server/actions/send-message.ts` using Zod validation, auth checks, rate limiter, and command queue dispatch
+- [ ] T019 [P] [US2] Add `apps/web/src/server/actions/add-reaction.ts` mirroring validation, auth, and logging requirements
+- [ ] T020 [P] [US2] Add `apps/web/src/server/actions/typing-start.ts` with shared guardrails and metrics emission
+- [ ] T021 [US2] Update `apps/web/src/server/gateway/gateway-ws.client.ts` to publish command lifecycle logs and expose queue saturation errors to callers
+- [ ] T022 [US2] Add Vitest coverage in `apps/web/tests/server/gateway-commands.test.ts` for rate limiting, auth failures, and queue overflow responses
+- [ ] T023 [US2] Add integration test `apps/web/tests/integration/gateway-commands.test.ts` to assert Gateway frames issued over the mocked socket and HTTP status mappings
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - Migrate existing realtime consumers to the unified bus (Priority: P3)
+
+**Goal**: Preserve voice dropout UX while routing all consumers through the unified event bus and optional legacy bridge
+
+**Independent Test**: Trigger a simulated voice dropout while the new gateway client runs, confirm `VoiceDropoutModal` behavior, absence of duplicate `/api/ws` sockets when flag disabled, and presence of queued commands during outages
+
+### Implementation for User Story 3
+
+- [ ] T024 [US3] Implement `apps/web/src/server/legacy/voice-bridge.ts` to relay bus events into `wsManager.broadcastToGuild` behind a feature flag
+- [ ] T025 [US3] Update `apps/web/src/server/managers/ws-manager.ts` and `apps/web/src/server/ws-server.server.ts` to consume the legacy bridge feed and expose connection gauges
+- [ ] T026 [US3] Update `apps/web/src/routes/api/ws.ts` to respect `ENABLE_WS_BRIDGE` and document deprecation messaging
+- [ ] T027 [US3] Refactor `apps/web/src/hooks/useVoiceChannelEvents.ts` to source events from `/api/stream` while reusing the bus adapter when SSE unavailable
+- [ ] T028 [US3] Update `apps/web/src/hooks/useVoiceChannelMembersFromEvents.ts` to rely on the unified hook outputs and drop direct WebSocket handling
+- [ ] T029 [US3] Add integration test `apps/web/tests/integration/voice-dropout-sse.test.ts` exercising the voice modal flow via SSE + legacy bridge toggle
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Repository-wide documentation, observability, and rollout cleanup
+
+- [ ] T030 Update `docs/VOICE_CHANNEL_EVENTS_REFACTOR.md` and related voice dropout docs with unified gateway + SSE architecture details
+- [ ] T031 Refresh `docs/IMPLEMENTATION_SUMMARY.md` and `docs/VOICE_DROPOUT_QUICK_START.md` with new server functions, feature flag instructions, and test steps
+- [ ] T032 Add operational runbook entry to `docs/VOICE_DROPOUT_CHECKLIST.md` covering queue saturation alerts and SSE monitoring
+- [ ] T033 Validate quickstart instructions in `specs/016-realtime-plan/quickstart.md` against the implemented endpoints and update if needed
+- [ ] T034 Perform final lint/test sweep (`pnpm lint`, `pnpm test`, `pnpm --filter @repo/web test`) and capture results in PR notes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phases 3-5)**: Each depends on Foundational phase completion; proceed in priority order (US1 → US2 → US3)
+- **Polish (Phase 6)**: Depends on completion of targeted user stories and associated tests
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Requires Phase 2 primitives. No dependency on other stories.
+- **User Story 2 (P2)**: Requires Phase 2 + User Story 1 gateway client exports.
+- **User Story 3 (P3)**: Requires Phases 2-4 to ensure unified bus and commands exist before migration.
+
+### Within Each User Story
+
+- Implement shared modules before consuming them (e.g., gateway client before SSE route).
+- Write or update tests immediately after implementing functionality.
+- Maintain observability (logging/metrics) alongside feature code to meet acceptance criteria.
+
+### Parallel Opportunities
+
+- [Setup] T001 and T002 can run concurrently.
+- [Foundational] T003-T008 touch distinct files and can proceed in parallel once environment prep finishes.
+- [US1] T010 and T011 can run alongside T009 once the client interface stabilizes.
+- [US2] T018-T020 can run in parallel; they depend on T017.
+- [US3] T027 and T028 can proceed together after bridge tasks (T024-T026) complete.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2 tasks.
+2. Deliver Phase 3 tasks to establish unified inbound streaming.
+3. Run independent tests (T015, T016) and validate SSE delivery before proceeding.
+
+### Incremental Delivery
+
+1. Foundation ready → ship US1 (core streaming).
+2. Layer US2 (commands + rate limiting) once gateway client dispatch ready.
+3. Migrate legacy consumers under US3 with feature flag guardrails.
+4. Finish with documentation and operational polish in Phase 6.
+
+### Parallel Team Strategy
+
+- Developer A: Focus on Foundational tasks T003-T008, then lead US1 (T009-T016).
+- Developer B: After Phase 2, tackle US2 command handlers (T017-T023).
+- Developer C: Once US1+US2 stabilized, migrate voice hooks under US3 (T024-T029) and drive polish tasks.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies; schedule them to maximize throughput.
+- Keep user stories independently testable; stop after each checkpoint for validation.
+- Maintain traceId propagation and metrics per acceptance criteria while implementing each module.
+- Update tasks as implementation reveals new shared primitives, keeping checklist format intact.


### PR DESCRIPTION
## Summary
- copy the consolidated realtime communications spec into the 016-realtime-plan feature directory for downstream workflows
- generate tasks.md outlining setup, foundational primitives, and phased user stories for the unified Discord gateway effort

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_690692b10da08326942b1ac2dda1f60f