### PR TITLE
Enable WebRTC webcam grid for game rooms

### DIFF
--- a/apps/web/src/components/GameRoom.tsx
+++ b/apps/web/src/components/GameRoom.tsx
@@ -491,6 +491,8 @@ function GameRoomContent({
             <VideoStreamGrid
               players={players}
               localPlayerName={playerName}
+              localPlayerId={discordUser?.id}
+              gameId={gameId}
               onLifeChange={handleLifeChange}
               enableCardDetection={true}
               detectorType={detectorType}
@@ -498,6 +500,7 @@ function GameRoomContent({
               onCardCrop={(canvas: HTMLCanvasElement) => {
                 query(canvas)
               }}
+              voiceJwtToken={wsTokenData}
             />
           </div>
         </div>

--- a/apps/web/src/components/VideoStreamGrid.tsx
+++ b/apps/web/src/components/VideoStreamGrid.tsx
@@ -1,6 +1,7 @@
 import type { DetectorType } from '@/lib/detectors'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useWebcam } from '@/hooks/useWebcam'
+import { useVoiceChannelEvents } from '@/hooks/useVoiceChannelEvents'
 import {
   Camera,
   Mic,
@@ -14,6 +15,8 @@ import {
   VolumeX,
 } from 'lucide-react'
 
+import { useServerFn } from '@tanstack/react-start'
+
 import { Button } from '@repo/ui/components/button'
 import { Card } from '@repo/ui/components/card'
 import {
@@ -21,6 +24,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@repo/ui/components/popover'
+
+import { broadcastWebRTCSignal } from '@/server/handlers/webrtc-signaling.server'
+import {
+  parseWebRTCSignalEnvelope,
+  type WebRTCSignalEnvelope,
+  type WebRTCSignalPayload,
+} from '@/types/webrtc'
 
 interface Player {
   id: string
@@ -32,6 +42,8 @@ interface Player {
 interface VideoStreamGridProps {
   players: Player[]
   localPlayerName: string
+  localPlayerId?: string
+  gameId: string
   onLifeChange: (playerId: string, newLife: number) => void
   /** Enable card detection with green borders and click-to-crop */
   enableCardDetection?: boolean
@@ -41,6 +53,8 @@ interface VideoStreamGridProps {
   usePerspectiveWarp?: boolean
   /** Callback when a card is cropped */
   onCardCrop?: (canvas: HTMLCanvasElement) => void
+  /** JWT token for SSE connection reuse */
+  voiceJwtToken?: string
 }
 
 interface StreamState {
@@ -51,11 +65,14 @@ interface StreamState {
 export function VideoStreamGrid({
   players,
   localPlayerName,
+  localPlayerId,
+  gameId,
   onLifeChange,
   enableCardDetection = true, // Always enabled by default
   detectorType,
   usePerspectiveWarp = true,
   onCardCrop,
+  voiceJwtToken,
 }: VideoStreamGridProps) {
   // Initialize webcam with card detection
   const {
@@ -96,6 +113,479 @@ export function VideoStreamGrid({
     ),
   )
 
+  const broadcastSignalFn = useServerFn(broadcastWebRTCSignal)
+  const peersRef = useRef(new Map<string, RTCPeerConnection>())
+  const pendingCandidatesRef = useRef(
+    new Map<string, RTCIceCandidateInit[]>(),
+  )
+  const readyPeersRef = useRef(new Set<string>())
+  const remoteVideoRefs = useRef<Record<string, HTMLVideoElement | null>>({})
+  const [remoteStreams, setRemoteStreams] = useState<Map<string, MediaStream>>(
+    () => new Map(),
+  )
+  const [localStream, setLocalStream] = useState<MediaStream | null>(null)
+  const readyStateRef = useRef(false)
+
+  useEffect(() => {
+    setStreamStates((prev) => {
+      const next: Record<string, StreamState> = {}
+      for (const player of players) {
+        next[player.id] = prev[player.id] ?? { video: true, audio: true }
+      }
+      return next
+    })
+  }, [players])
+
+  const setRemoteStream = useCallback(
+    (peerId: string, stream: MediaStream | null) => {
+      setRemoteStreams((prev) => {
+        const next = new Map(prev)
+        if (stream) {
+          next.set(peerId, stream)
+        } else {
+          next.delete(peerId)
+        }
+        return next
+      })
+    },
+    [],
+  )
+
+  useEffect(() => {
+    remoteStreams.forEach((stream, peerId) => {
+      const videoEl = remoteVideoRefs.current[peerId]
+      if (videoEl && videoEl.srcObject !== stream) {
+        videoEl.srcObject = stream
+        videoEl.playsInline = true
+        videoEl.autoplay = true
+        void videoEl.play().catch((error) => {
+          console.warn(
+            '[VideoStreamGrid] Failed to play remote stream',
+            error,
+          )
+        })
+      }
+    })
+
+    for (const [peerId, element] of Object.entries(remoteVideoRefs.current)) {
+      if (!remoteStreams.has(peerId) && element && element.srcObject) {
+        element.srcObject = null
+      }
+    }
+  }, [remoteStreams])
+
+  useEffect(() => {
+    for (const [peerId, element] of Object.entries(remoteVideoRefs.current)) {
+      if (!element) continue
+      const state = streamStates[peerId]
+      if (state) {
+        element.muted = !state.audio
+      }
+    }
+  }, [streamStates])
+
+  const handleRemoteVideoRef = useCallback(
+    (playerId: string, element: HTMLVideoElement | null) => {
+      if (!element) {
+        delete remoteVideoRefs.current[playerId]
+        return
+      }
+
+      remoteVideoRefs.current[playerId] = element
+
+      const stream = remoteStreams.get(playerId)
+      if (stream && element.srcObject !== stream) {
+        element.srcObject = stream
+        element.playsInline = true
+        element.autoplay = true
+        void element.play().catch((error) => {
+          console.warn('[VideoStreamGrid] Failed to play remote stream', error)
+        })
+      }
+
+      const state = streamStates[playerId]
+      if (state) {
+        element.muted = !state.audio
+      }
+    },
+    [remoteStreams, streamStates],
+  )
+
+  const sendSignal = useCallback(
+    async (targetUserId: string | null, signal: WebRTCSignalPayload) => {
+      if (!localPlayerId) {
+        return
+      }
+
+      try {
+        await broadcastSignalFn({
+          data: {
+            gameId,
+            fromUserId: localPlayerId,
+            targetUserId,
+            signal,
+          } satisfies WebRTCSignalEnvelope,
+        })
+      } catch (error) {
+        console.error('[VideoStreamGrid] Failed to send WebRTC signal', error)
+      }
+    },
+    [broadcastSignalFn, gameId, localPlayerId],
+  )
+
+  const closePeerConnection = useCallback(
+    (peerId: string) => {
+      const connection = peersRef.current.get(peerId)
+      if (connection) {
+        try {
+          connection.close()
+        } catch (error) {
+          console.warn(
+            '[VideoStreamGrid] Error closing peer connection',
+            error,
+          )
+        }
+        peersRef.current.delete(peerId)
+      }
+      setRemoteStream(peerId, null)
+      pendingCandidatesRef.current.delete(peerId)
+      readyPeersRef.current.delete(peerId)
+    },
+    [setRemoteStream],
+  )
+
+  const resetPeerConnections = useCallback(() => {
+    for (const peerId of peersRef.current.keys()) {
+      closePeerConnection(peerId)
+    }
+  }, [closePeerConnection])
+
+  const flushCandidateQueue = useCallback(
+    async (peerId: string, connection: RTCPeerConnection) => {
+      const queue = pendingCandidatesRef.current.get(peerId)
+      if (!queue || queue.length === 0) {
+        return
+      }
+
+      pendingCandidatesRef.current.delete(peerId)
+
+      for (const candidateInit of queue) {
+        try {
+          const candidate = new RTCIceCandidate(candidateInit)
+          await connection.addIceCandidate(candidate)
+        } catch (error) {
+          console.error(
+            '[VideoStreamGrid] Failed to add queued ICE candidate',
+            error,
+          )
+        }
+      }
+    },
+    [],
+  )
+
+  const createPeerConnection = useCallback(
+    (peerId: string) => {
+      const existing = peersRef.current.get(peerId)
+      if (existing) {
+        return existing
+      }
+
+      const connection = new RTCPeerConnection({
+        iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+      })
+
+      if (localStream) {
+        for (const track of localStream.getTracks()) {
+          connection.addTrack(track, localStream)
+        }
+      }
+
+      connection.onicecandidate = (event) => {
+        if (!event.candidate) {
+          return
+        }
+
+        void sendSignal(peerId, {
+          type: 'ice-candidate',
+          candidate: event.candidate.toJSON(),
+        })
+      }
+
+      connection.ontrack = (event) => {
+        const [stream] = event.streams
+        if (stream) {
+          setRemoteStream(peerId, stream)
+        }
+      }
+
+      connection.onconnectionstatechange = () => {
+        if (
+          connection.connectionState === 'failed' ||
+          connection.connectionState === 'disconnected' ||
+          connection.connectionState === 'closed'
+        ) {
+          closePeerConnection(peerId)
+        }
+      }
+
+      peersRef.current.set(peerId, connection)
+      return connection
+    },
+    [closePeerConnection, localStream, sendSignal, setRemoteStream],
+  )
+
+  const attemptOffer = useCallback(
+    async (peerId: string) => {
+      if (!localStream || !localPlayerId) {
+        return
+      }
+
+      const connection = createPeerConnection(peerId)
+
+      if (connection.signalingState !== 'stable') {
+        return
+      }
+
+      try {
+        const offer = await connection.createOffer()
+        await connection.setLocalDescription(offer)
+        await sendSignal(peerId, { type: 'offer', sdp: offer })
+      } catch (error) {
+        console.error('[VideoStreamGrid] Failed to create offer', error)
+      }
+    },
+    [createPeerConnection, localPlayerId, localStream, sendSignal],
+  )
+
+  const handleSignal = useCallback(
+    async (envelope: WebRTCSignalEnvelope) => {
+      const { fromUserId, targetUserId, signal } = envelope
+
+      if (!localPlayerId) {
+        return
+      }
+
+      if (fromUserId === localPlayerId) {
+        return
+      }
+
+      if (targetUserId && targetUserId !== localPlayerId) {
+        return
+      }
+
+      switch (signal.type) {
+        case 'leave': {
+          closePeerConnection(fromUserId)
+          return
+        }
+        case 'ready': {
+          readyPeersRef.current.add(fromUserId)
+          if (!localStream || !isVideoActive) {
+            return
+          }
+
+          if (localPlayerId < fromUserId) {
+            await attemptOffer(fromUserId)
+          } else {
+            createPeerConnection(fromUserId)
+          }
+          return
+        }
+        case 'offer': {
+          readyPeersRef.current.add(fromUserId)
+          if (!signal.sdp) {
+            return
+          }
+
+          if (!localStream || !isVideoActive) {
+            console.warn(
+              '[VideoStreamGrid] Offer received without active local stream',
+            )
+            return
+          }
+
+          const connection = createPeerConnection(fromUserId)
+          try {
+            await connection.setRemoteDescription(
+              new RTCSessionDescription(signal.sdp),
+            )
+            const answer = await connection.createAnswer()
+            await connection.setLocalDescription(answer)
+            await sendSignal(fromUserId, { type: 'answer', sdp: answer })
+            await flushCandidateQueue(fromUserId, connection)
+          } catch (error) {
+            console.error('[VideoStreamGrid] Failed to handle offer', error)
+          }
+          return
+        }
+        case 'answer': {
+          if (!signal.sdp) {
+            return
+          }
+
+          const connection = peersRef.current.get(fromUserId)
+          if (!connection) {
+            return
+          }
+
+          try {
+            await connection.setRemoteDescription(
+              new RTCSessionDescription(signal.sdp),
+            )
+            await flushCandidateQueue(fromUserId, connection)
+          } catch (error) {
+            console.error('[VideoStreamGrid] Failed to handle answer', error)
+          }
+          return
+        }
+        case 'ice-candidate': {
+          if (!signal.candidate) {
+            return
+          }
+
+          const connection = createPeerConnection(fromUserId)
+
+          if (connection.remoteDescription) {
+            try {
+              await connection.addIceCandidate(
+                new RTCIceCandidate(signal.candidate),
+              )
+            } catch (error) {
+              console.error(
+                '[VideoStreamGrid] Failed to add ICE candidate',
+                error,
+              )
+            }
+          } else {
+            const queue =
+              pendingCandidatesRef.current.get(fromUserId) ?? []
+            queue.push(signal.candidate)
+            pendingCandidatesRef.current.set(fromUserId, queue)
+          }
+          return
+        }
+        default:
+          return
+      }
+    },
+    [
+      attemptOffer,
+      closePeerConnection,
+      createPeerConnection,
+      flushCandidateQueue,
+      isVideoActive,
+      localPlayerId,
+      localStream,
+      sendSignal,
+    ],
+  )
+
+  useEffect(() => {
+    peersRef.current.forEach((connection) => {
+      const senders = connection.getSenders()
+
+      if (!localStream) {
+        senders.forEach((sender) => {
+          if (sender.track) {
+            sender.replaceTrack(null).catch((error) => {
+              console.warn(
+                '[VideoStreamGrid] Failed to clear sender track',
+                error,
+              )
+            })
+          }
+        })
+        return
+      }
+
+      for (const track of localStream.getTracks()) {
+        const sender = senders.find((s) => s.track?.kind === track.kind)
+        if (sender) {
+          sender.replaceTrack(track).catch((error) => {
+            console.warn(
+              '[VideoStreamGrid] Failed to replace track on sender',
+              error,
+            )
+          })
+        } else {
+          connection.addTrack(track, localStream)
+        }
+      }
+    })
+  }, [localStream])
+
+  useEffect(() => {
+    if (!localPlayerId) {
+      return
+    }
+
+    const isStreaming = Boolean(localStream && isVideoActive)
+
+    if (isStreaming && !readyStateRef.current) {
+      readyStateRef.current = true
+      void sendSignal(null, { type: 'ready' })
+      readyPeersRef.current.forEach((peerId) => {
+        if (localPlayerId < peerId) {
+          void attemptOffer(peerId)
+        }
+      })
+    } else if (!isStreaming && readyStateRef.current) {
+      readyStateRef.current = false
+      void sendSignal(null, { type: 'leave' })
+      resetPeerConnections()
+    }
+  }, [attemptOffer, isVideoActive, localPlayerId, localStream, resetPeerConnections, sendSignal])
+
+  useEffect(() => {
+    return () => {
+      resetPeerConnections()
+      if (readyStateRef.current && localPlayerId) {
+        readyStateRef.current = false
+        void sendSignal(null, { type: 'leave' })
+      }
+    }
+  }, [localPlayerId, resetPeerConnections, sendSignal])
+
+  useEffect(() => {
+    const playerIds = new Set(players.map((player) => player.id))
+    peersRef.current.forEach((_, peerId) => {
+      if (!playerIds.has(peerId)) {
+        closePeerConnection(peerId)
+      }
+    })
+  }, [closePeerConnection, players])
+
+  useEffect(() => {
+    if (isVideoActive && videoRef.current?.srcObject instanceof MediaStream) {
+      setLocalStream(videoRef.current.srcObject)
+    }
+
+    if (!isVideoActive) {
+      setLocalStream(null)
+    }
+  }, [isVideoActive])
+
+  useVoiceChannelEvents({
+    jwtToken: voiceJwtToken,
+    onCustomEvent: (event) => {
+      if (event.event !== 'webrtc.signal') {
+        return
+      }
+
+      const parsed = parseWebRTCSignalEnvelope(event.payload)
+      if (!parsed) {
+        return
+      }
+
+      if (parsed.gameId !== gameId) {
+        return
+      }
+
+      void handleSignal(parsed)
+    },
+  })
+
   // Find local player (not currently used but may be needed for future features)
   // const localPlayer = players.find((p) => p.name === localPlayerName)
 
@@ -112,6 +602,9 @@ export function VideoStreamGrid({
     )
     if (cameraIndex !== -1) {
       await startVideo(deviceId)
+      if (videoRef.current?.srcObject instanceof MediaStream) {
+        setLocalStream(videoRef.current.srcObject)
+      }
       setCurrentCameraIndex(cameraIndex)
       setCurrentCameraId(deviceId)
       setCameraPopoverOpen(false)
@@ -168,10 +661,13 @@ export function VideoStreamGrid({
         const isLocal = player.name === localPlayerName
         const state = streamStates[player.id] || { video: true, audio: true }
 
-        // For local player, video is always enabled (card detection mode)
-        // For remote players, use UI state
-        const videoEnabled = isLocal ? true : state.video
-        const audioEnabled = isLocal ? true : state.audio
+        const audioEnabled = isLocal ? !isAudioMuted : state.audio
+        const remoteStream = remoteStreams.get(player.id) || null
+        const remoteVideoActive = !isLocal && !!remoteStream && state.video
+        const showCameraOff = !isLocal && !state.video
+        const showPlaceholder =
+          (isLocal && !isVideoActive) ||
+          (!isLocal && state.video && !remoteVideoActive)
 
         return (
           <Card
@@ -237,30 +733,36 @@ export function VideoStreamGrid({
                 </>
               )}
 
+              {!isLocal && remoteVideoActive && (
+                <video
+                  ref={(element) => handleRemoteVideoRef(player.id, element)}
+                  autoPlay
+                  playsInline
+                  muted={!audioEnabled}
+                  className="absolute inset-0 h-full w-full object-contain"
+                />
+              )}
+
               {/* Placeholder UI */}
-              {videoEnabled ? (
-                <>
-                  {!(isLocal && isVideoActive) && (
-                    <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
-                      <div className="space-y-3 text-center">
-                        <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-purple-500/20">
-                          <Camera className="h-10 w-10 text-purple-400" />
-                        </div>
-                        <p className="text-slate-400">
-                          {isLocal
-                            ? 'Your Table View'
-                            : `${player.name}'s Table View`}
-                        </p>
-                        <p className="text-sm text-slate-500">
-                          {isLocal
-                            ? 'Click camera button to start'
-                            : 'Camera feed of physical battlefield'}
-                        </p>
-                      </div>
+              {showPlaceholder && (
+                <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
+                  <div className="space-y-3 text-center">
+                    <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-purple-500/20">
+                      <Camera className="h-10 w-10 text-purple-400" />
                     </div>
-                  )}
-                </>
-              ) : (
+                    <p className="text-slate-400">
+                      {isLocal ? 'Your Table View' : `${player.name}'s Table View`}
+                    </p>
+                    <p className="text-sm text-slate-500">
+                      {isLocal
+                        ? 'Click camera button to start'
+                        : 'Camera feed of physical battlefield'}
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {showCameraOff && (
                 <div className="absolute inset-0 flex items-center justify-center bg-slate-950">
                   <div className="space-y-2 text-center">
                     <VideoOff className="mx-auto h-12 w-12 text-slate-600" />
@@ -339,9 +841,13 @@ export function VideoStreamGrid({
                     onClick={async () => {
                       if (!isVideoActive) {
                         await startVideo()
+                        if (videoRef.current?.srcObject instanceof MediaStream) {
+                          setLocalStream(videoRef.current.srcObject)
+                        }
                         setHasStartedVideo(true)
                       } else {
                         stopVideo()
+                        setLocalStream(null)
                       }
                     }}
                     className={`h-10 w-10 p-0 ${

--- a/apps/web/src/server/handlers/webrtc-signaling.server.ts
+++ b/apps/web/src/server/handlers/webrtc-signaling.server.ts
@@ -1,0 +1,28 @@
+import { env } from '@/env'
+import { createServerFn } from '@tanstack/react-start'
+
+import { sseManager } from '../managers/sse-manager.js'
+
+import {
+  WebRTCSignalEnvelopeSchema,
+  type WebRTCSignalEnvelope,
+} from '@/types/webrtc'
+
+export const broadcastWebRTCSignal = createServerFn({ method: 'POST' })
+  .inputValidator((data: WebRTCSignalEnvelope) =>
+    WebRTCSignalEnvelopeSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const payload: WebRTCSignalEnvelope = {
+      ...data,
+      targetUserId: data.targetUserId ?? null,
+    }
+
+    sseManager.broadcastCustomEventToGuild(
+      env.VITE_DISCORD_GUILD_ID,
+      'webrtc.signal',
+      payload,
+    )
+
+    return { ok: true }
+  })

--- a/apps/web/src/types/sse-messages.ts
+++ b/apps/web/src/types/sse-messages.ts
@@ -20,7 +20,7 @@ export const SSEMessageBaseSchema = z.object({
 /**
  * Custom application event names
  */
-export type CustomEventName = 'voice.joined' | 'voice.left'
+export type CustomEventName = 'voice.joined' | 'voice.left' | 'webrtc.signal'
 
 /**
  * SSE Discord Gateway Event Message - Raw Discord events
@@ -40,7 +40,7 @@ export type SSEDiscordEventMessage = z.infer<
  */
 export const SSECustomEventMessageSchema = SSEMessageBaseSchema.extend({
   type: z.literal('custom.event'),
-  event: z.enum(['voice.joined', 'voice.left']), // Custom event names
+  event: z.enum(['voice.joined', 'voice.left', 'webrtc.signal']), // Custom event names
   payload: z.unknown(), // Custom event payload
 })
 

--- a/apps/web/src/types/webrtc.ts
+++ b/apps/web/src/types/webrtc.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+export const WebRTCSignalPayloadSchema = z.object({
+  type: z.enum(['ready', 'offer', 'answer', 'ice-candidate', 'leave']),
+  sdp: z
+    .object({
+      type: z.enum(['offer', 'answer']),
+      sdp: z.string(),
+    })
+    .optional(),
+  candidate: z
+    .object({
+      candidate: z.string(),
+      sdpMid: z.string().nullable().optional(),
+      sdpMLineIndex: z.number().nullable().optional(),
+      usernameFragment: z.string().optional(),
+    })
+    .optional(),
+})
+
+export type WebRTCSignalPayload = z.infer<typeof WebRTCSignalPayloadSchema>
+
+export const WebRTCSignalEnvelopeSchema = z.object({
+  gameId: z.string(),
+  fromUserId: z.string(),
+  targetUserId: z.string().nullable().optional(),
+  signal: WebRTCSignalPayloadSchema,
+})
+
+export type WebRTCSignalEnvelope = z.infer<typeof WebRTCSignalEnvelopeSchema>
+
+export function parseWebRTCSignalEnvelope(
+  value: unknown,
+): WebRTCSignalEnvelope | null {
+  const result = WebRTCSignalEnvelopeSchema.safeParse(value)
+  return result.success ? result.data : null
+}


### PR DESCRIPTION
## Summary
- add a server-side WebRTC signaling hook and supporting types for SSE broadcast
- extend the voice event hook and SSE message schema to deliver custom WebRTC signals
- wire the video grid to manage RTCPeerConnection mesh streams and display remote webcams in each game room

## Testing
- bun run typecheck *(fails: GET https://registry.npmjs.org/turbo - 403)*

------
https://chatgpt.com/codex/tasks/task_e_69090be1acfc8326917af4888cadc4f2