### PR TITLE
Remove turn tracking (roomState/turn) from Convex backend and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Spell Coven aims to provide a comprehensive remote play experience for Magic: Th
 
 - **Multi-party Video & Voice**: Browser-based video chat optimized for overhead camera views of playmats (2-4 players per game)
 - **Intelligent Card Recognition**: Computer vision powered by CLIP to identify cards in real-time and display rulings/details
-- **Game Management Tools**: Life total tracking, commander damage tracking, turn indicators, and game timers
+- **Game Management Tools**: Life total tracking, commander damage tracking, and game timers
 - **Flexible Room System**: Create or join private/public game rooms with format and power level metadata for better matchmaking
 - **Device Flexibility**: Use standard webcams or mobile devices as overhead cameras without separate apps
 - **Fully Browser-Based**: No installation required—works on modern browsers (Chrome, Firefox, Safari)
@@ -24,7 +24,7 @@ Spell Coven aims to provide a comprehensive remote play experience for Magic: Th
 - ✅ Pre-computed embeddings for ~20k+ MTG cards
 
 **Phase 2 (Planned)**: Multi-party video/audio and room system
-**Phase 3 (Planned)**: Game aids (life tracking, commander damage, turn management)
+**Phase 3 (Planned)**: Game aids (life tracking, commander damage, game timers)
 **Phase 4 (Planned)**: Enhanced matchmaking and social features
 
 ## Target Use Case
@@ -34,7 +34,7 @@ Spell Coven is designed for Magic: The Gathering players who want to play with t
 - **Remote Play Sessions**: Play paper MTG with friends across distances using video chat
 - **Casual & Competitive Play**: Support for various formats (Commander, Modern, Standard, etc.) with power level indicators
 - **Card Identification**: Quickly identify cards on camera for rules lookups and oracle text
-- **Game State Tracking**: Keep track of life totals, commander damage, and turn order
+- **Game State Tracking**: Keep track of life totals and commander damage
 - **Flexible Setup**: Use any webcam or smartphone as an overhead camera—no special equipment needed
 
 ### Competitive Landscape
@@ -44,7 +44,7 @@ Spell Coven is designed for Magic: The Gathering players who want to play with t
 - Multi-party video chat (2-4 players)
 - Card recognition with click-to-identify
 - Built-in life/commander damage tracking
-- Turn indicators and timers
+- Timers
 - Mobile device support as overhead cameras
 
 **Spell Coven's Differentiators** (planned):

--- a/apps/web/ROOM_MANAGEMENT.md
+++ b/apps/web/ROOM_MANAGEMENT.md
@@ -4,16 +4,15 @@ This document describes how game rooms are created, validated, and maintained.
 
 ## Overview
 
-Rooms are first-class Convex records. Creating a room writes to `rooms` and
-`roomState`, and presence is tracked in `roomPlayers`. WebRTC signaling moves
-through `roomSignals`.
+Rooms are first-class Convex records. Creating a room writes to `rooms`,
+presence is tracked in `roomPlayers`, and WebRTC signaling moves through
+`roomSignals`.
 
 ## Data Model
 
 Convex tables involved in room management:
 
 - `rooms`: metadata for each room (owner, status, createdAt)
-- `roomState`: per-room turn and state
 - `roomPlayers`: presence, sessions, and player stats
 - `roomSignals`: WebRTC signaling messages
 - `roomBans`: persistent bans
@@ -37,7 +36,7 @@ The landing page calls `api.rooms.createRoom`. The server:
 2. Enforces a per-user throttle (5s cooldown)
 3. Increments the `counters` record
 4. Generates a new room ID
-5. Inserts `rooms` and `roomState`
+5. Inserts `rooms`
 
 Room ID creation happens server-side; the client only receives the final code.
 

--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -833,7 +833,7 @@ export function LandingPage({
                 </div>
                 <h3 className="mb-3 text-xl text-white">Game Management</h3>
                 <p className="text-slate-400">
-                  Life counters, turn tracking, and game state tools to keep
+                  Life counters, commander damage, and game state tools to keep
                   everything organized.
                 </p>
               </SpotlightCard>

--- a/convex/README.md
+++ b/convex/README.md
@@ -64,7 +64,6 @@ convex/
 | Table         | Purpose                                   |
 | ------------- | ----------------------------------------- |
 | `rooms`       | Room metadata (owner, status)             |
-| `roomState`   | Game state (current turn, turn number)    |
 | `roomPlayers` | Players in rooms (also used for presence) |
 | `roomSignals` | WebRTC signaling messages                 |
 | `roomBans`    | Persistent ban records                    |
@@ -85,13 +84,12 @@ bun run dev
 
 The Convex backend is currently in **Phase 3** of the Supabase → Convex migration:
 
-| Feature    | Status     | Notes                       |
-| ---------- | ---------- | --------------------------- |
-| Schema     | ✅ Done    | All tables defined          |
-| Room State | ✅ Done    | Mutations work without auth |
-| Presence   | ✅ Done    | `useConvexPresence` hook    |
-| Signaling  | ⏳ Phase 4 | Using Supabase broadcast    |
-| Auth       | ⏳ Phase 5 | Using Supabase Auth         |
+| Feature   | Status     | Notes                       |
+| --------- | ---------- | --------------------------- |
+| Schema    | ✅ Done    | All tables defined          |
+| Presence  | ✅ Done    | `useConvexPresence` hook    |
+| Signaling | ⏳ Phase 4 | Using Supabase broadcast    |
+| Auth      | ⏳ Phase 5 | Using Supabase Auth         |
 
 ### Phase 3 Notes
 

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -17,21 +17,17 @@ export const ErrorCode = {
   AUTH_REQUIRED: 'AUTH_REQUIRED',
   AUTH_MISMATCH: 'AUTH_MISMATCH',
   NOT_ROOM_OWNER: 'NOT_ROOM_OWNER',
-  NOT_CURRENT_TURN: 'NOT_CURRENT_TURN',
   BANNED_FROM_ROOM: 'BANNED_FROM_ROOM',
   CANNOT_TARGET_SELF: 'CANNOT_TARGET_SELF',
 
   // Not Found
   ROOM_NOT_FOUND: 'ROOM_NOT_FOUND',
-  ROOM_STATE_NOT_FOUND: 'ROOM_STATE_NOT_FOUND',
   PLAYER_NOT_FOUND: 'PLAYER_NOT_FOUND',
-  NO_ACTIVE_PLAYERS: 'NO_ACTIVE_PLAYERS',
 
   // Validation
   MISSING_USER_ID: 'MISSING_USER_ID',
 
   // Server/Internal
-  TURN_ADVANCE_FAILED: 'TURN_ADVANCE_FAILED',
 } as const
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
@@ -74,13 +70,6 @@ export class NotRoomOwnerError extends AppError {
   }
 }
 
-export class NotCurrentTurnError extends AppError {
-  constructor(message = 'Only the current turn player can advance turn') {
-    super(ErrorCode.NOT_CURRENT_TURN, message)
-    this.name = 'NotCurrentTurnError'
-  }
-}
-
 export class BannedFromRoomError extends AppError {
   constructor(message = 'You are banned from this room') {
     super(ErrorCode.BANNED_FROM_ROOM, message)
@@ -106,24 +95,10 @@ export class RoomNotFoundError extends AppError {
   }
 }
 
-export class RoomStateNotFoundError extends AppError {
-  constructor(message = 'Room state not found') {
-    super(ErrorCode.ROOM_STATE_NOT_FOUND, message)
-    this.name = 'RoomStateNotFoundError'
-  }
-}
-
 export class PlayerNotFoundError extends AppError {
   constructor(message = 'Player not found in room') {
     super(ErrorCode.PLAYER_NOT_FOUND, message)
     this.name = 'PlayerNotFoundError'
-  }
-}
-
-export class NoActivePlayersError extends AppError {
-  constructor(message = 'No active players in room') {
-    super(ErrorCode.NO_ACTIVE_PLAYERS, message)
-    this.name = 'NoActivePlayersError'
   }
 }
 
@@ -135,17 +110,6 @@ export class MissingUserIdError extends AppError {
   constructor(message = 'userId is required') {
     super(ErrorCode.MISSING_USER_ID, message)
     this.name = 'MissingUserIdError'
-  }
-}
-
-// ============================================================================
-// Server/Internal Errors
-// ============================================================================
-
-export class TurnAdvanceFailedError extends AppError {
-  constructor(message = 'Failed to determine next player') {
-    super(ErrorCode.TURN_ADVANCE_FAILED, message)
-    this.name = 'TurnAdvanceFailedError'
   }
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -51,22 +51,6 @@ export default defineSchema({
     .index('by_ownerId_createdAt', ['ownerId', 'createdAt']),
 
   /**
-   * roomState - Game state for a room
-   *
-   * One-to-one with rooms. Tracks whose turn it is and turn number.
-   */
-  roomState: defineTable({
-    /** Reference to room */
-    roomId: v.string(),
-    /** Discord user ID of current turn player */
-    currentTurnUserId: v.string(),
-    /** Current turn number (starts at 1) */
-    turnNumber: v.number(),
-    /** Last update timestamp */
-    lastUpdatedAt: v.number(),
-  }).index('by_roomId', ['roomId']),
-
-  /**
    * roomPlayers - Players in a room (also used for presence)
    *
    * Supports multi-tab sessions via sessionId.


### PR DESCRIPTION
### Motivation
- The project no longer needs to track turn order or turn counts so turn-related state and operations were removed to simplify the backend model and UI copy.

### Description
- Removed the `roomState` table and all references to it from the Convex schema (`convex/schema.ts`).
- Dropped turn-related mutations and logic from the backend (`convex/rooms.ts`) including `setTurn`, `advanceTurn`, creation of initial turn state, and returning `state` from `getRoom`.
- Removed turn-related error codes and classes from `convex/errors.ts` (`NOT_CURRENT_TURN`, `ROOM_STATE_NOT_FOUND`, `NO_ACTIVE_PLAYERS`, `TURN_ADVANCE_FAILED` and their exception classes).
- Updated documentation and UI copy to remove mentions of turn tracking including `README.md`, `convex/README.md`, `SUPABASE_TO_CONVEX_PLAN.md`, `apps/web/ROOM_MANAGEMENT.md`, and the landing page component `apps/web/src/components/LandingPage.tsx`.

### Testing
- Attempted to run the dev server with `bun run dev`, but the command failed due to an external registry access error (`npm registry 403`), so runtime integration tests were not executed.
- No automated unit tests were run as part of this change in the current environment due to the dev server failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c512e5b5483268cbabc1bc9299324)