### PR TITLE
Add configurable support link (Buy me a coffee) to landing page footer

### DIFF
--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import type { AuthUser } from '@/contexts/AuthContext'
+import { env } from '@/env'
 import { useMemo, useState } from 'react'
 import { sessionStorage } from '@/lib/session-storage'
 import { useNavigate } from '@tanstack/react-router'
@@ -78,6 +79,7 @@ export function LandingPage({
   onSignOut,
 }: LandingPageProps) {
   const navigate = useNavigate()
+  const supportUrl = env.VITE_SUPPORT_URL
   const [joinGameId, setJoinGameId] = useState('')
   const [dialogs, setDialogs] = useState({
     join: false,
@@ -965,7 +967,11 @@ export function LandingPage({
         {/* Footer */}
         <footer className="border-t border-slate-800 bg-slate-950">
           <div className="container mx-auto px-4 py-12">
-            <div className="grid gap-8 md:grid-cols-4">
+            <div
+              className={`grid gap-8 ${
+                supportUrl ? 'md:grid-cols-5' : 'md:grid-cols-4'
+              }`}
+            >
               <div className="col-span-2 space-y-4">
                 <div className="flex items-center gap-2">
                   <img
@@ -1034,6 +1040,26 @@ export function LandingPage({
                   </li>
                 </ul>
               </div>
+
+              {supportUrl && (
+                <div>
+                  <h4 className="mb-4 text-sm font-semibold text-white">
+                    Support
+                  </h4>
+                  <p className="mb-4 text-sm text-slate-400">
+                    Enjoying Spell Coven? Support ongoing development.
+                  </p>
+                  <a
+                    href={supportUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/30 transition hover:bg-purple-500"
+                  >
+                    <Heart className="h-4 w-4" />
+                    Buy me a coffee
+                  </a>
+                </div>
+              )}
             </div>
 
             <div className="mt-12 border-t border-slate-800 pt-8 text-center text-sm text-slate-500">

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -36,6 +36,7 @@ export const env = createEnv({
       .string()
       .min(1, 'Embeddings version is required'),
     VITE_BLOB_STORAGE_URL: z.url().min(1, 'Blob storage URL is required'),
+    VITE_SUPPORT_URL: z.url().optional(),
   },
 
   /**
@@ -48,6 +49,7 @@ export const env = createEnv({
     VITE_BASE_URL: import.meta.env.VITE_BASE_URL,
     VITE_EMBEDDINGS_VERSION: import.meta.env.VITE_EMBEDDINGS_VERSION,
     VITE_BLOB_STORAGE_URL: import.meta.env.VITE_BLOB_STORAGE_URL,
+    VITE_SUPPORT_URL: import.meta.env.VITE_SUPPORT_URL,
   },
 
   /**
@@ -93,5 +95,6 @@ export function getClientEnv() {
     VITE_BASE_URL: env.VITE_BASE_URL,
     VITE_EMBEDDINGS_VERSION: env.VITE_EMBEDDINGS_VERSION,
     VITE_BLOB_STORAGE_URL: env.VITE_BLOB_STORAGE_URL,
+    VITE_SUPPORT_URL: env.VITE_SUPPORT_URL,
   }
 }


### PR DESCRIPTION
### Motivation
- Provide an easy, configurable way for visitors to support the project (e.g., “Buy me a coffee”) without hard-coding a provider URL, so deployers can pick a payout-friendly provider for Sweden or other countries.

### Description
- Add an optional `VITE_SUPPORT_URL` environment variable to `apps/web/src/env.ts` and expose it via `getClientEnv()` for safe, typed access. 
- Read `env.VITE_SUPPORT_URL` in `LandingPage` and conditionally render a Support column with a “Buy me a coffee” CTA that links to the configured URL and opens in a new tab. 
- Adjust footer layout to use `md:grid-cols-5` when the support column is present and keep `md:grid-cols-4` otherwise.

### Testing
- Attempted to run dependency install and start the dev server with `bun install` and `bun run dev`, but installation failed due to 403 errors from the npm registry (so the dev server and automated tests were not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c50ac1dc48326bc346721a0a84260)