### PR TITLE
Use useSyncExternalStore for window/mobile hooks and useEffectEvent for audio callbacks

### DIFF
--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -3,17 +3,22 @@ import * as React from 'react'
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const getSnapshot = () =>
+    typeof window !== 'undefined'
+      ? window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches
+      : false
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+  const getServerSnapshot = () => false
+
+  const subscribe = (listener: () => void) => {
+    if (typeof window === 'undefined') {
+      return () => undefined
     }
-    mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener('change', onChange)
-  }, [])
 
-  return !!isMobile
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    mql.addEventListener('change', listener)
+    return () => mql.removeEventListener('change', listener)
+  }
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
### Motivation
- Reduce reliance on `useEffect`/`useRef` for simple responsive subscriptions and stable callbacks by adopting `useSyncExternalStore` and `useEffectEvent` where appropriate. 
- Improve stability and remove manual ref bookkeeping for audio callbacks, and centralize resize/matchMedia subscriptions to avoid duplicated listeners and unnecessary renders.

### Description
- Replaced the window-size hook `useWindowSize` with a shared `useSyncExternalStore` store implementing `subscribe`, `getSnapshot`, and `getServerSnapshot` to publish resize updates from a single listener and avoid per-hook `useEffect` state. 
- Updated the mobile breakpoint hook `useIsMobile` to use `React.useSyncExternalStore` with a `matchMedia` subscription instead of local `useState` + `useEffect`. 
- Replaced callback refs in `useAudioOutput` with `useEffectEvent` handlers (`handleDeviceChanged` and `handleError`), removed the manual ref-updating `useEffect`, and wired all error/device callbacks to the new stable handlers. 

### Testing
- No automated tests were executed for these changes (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e11abd8c883268e2b25e01f9757be)