### PR TITLE
Landing page GitHub link

### DIFF
--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -9,6 +9,7 @@ import {
   ArrowLeft,
   Check,
   Copy,
+  Github,
   LogIn,
   LogOut,
   Menu,
@@ -189,6 +190,17 @@ function LandingHeader({ navItems = [], onSignIn }: AppHeaderProps) {
             </a>
           ))}
 
+          <a
+            href="https://github.com/FrimJo/spell-coven-mono"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-text-secondary hover:text-text-primary flex items-center gap-1.5 transition-colors"
+            title="View on GitHub"
+          >
+            <Github className="h-5 w-5" />
+            <span className="sr-only">GitHub</span>
+          </a>
+
           <ThemeToggle />
 
           {/* Auth section */}
@@ -243,6 +255,17 @@ function LandingHeader({ navItems = [], onSignIn }: AppHeaderProps) {
                     {item.label}
                   </a>
                 ))}
+
+                {/* GitHub link in mobile menu */}
+                <a
+                  href="https://github.com/FrimJo/spell-coven-mono"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-text-secondary hover:bg-surface-2 hover:text-text-primary flex items-center gap-3 rounded-lg px-4 py-3 text-lg font-medium transition-colors"
+                >
+                  <Github className="h-5 w-5" />
+                  GitHub
+                </a>
 
                 {/* Theme toggle in mobile menu */}
                 <div className="flex items-center justify-between rounded-lg px-4 py-3">

--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -9,6 +9,7 @@ import {
   Camera,
   ChevronDown,
   Gamepad2,
+  Github,
   Heart,
   Loader2,
   LogOut,
@@ -937,7 +938,7 @@ export function LandingPage({
           <div className="container mx-auto px-4 py-12">
             <div
               className={`grid gap-8 ${
-                supportUrl ? 'md:grid-cols-5' : 'md:grid-cols-4'
+                supportUrl ? 'md:grid-cols-6' : 'md:grid-cols-5'
               }`}
             >
               <div className="col-span-2 space-y-4">
@@ -1009,6 +1010,24 @@ export function LandingPage({
                     </a>
                   </li>
                 </ul>
+              </div>
+
+              <div>
+                <h4 className="text-text-primary mb-4 text-sm font-semibold">
+                  Open Source
+                </h4>
+                <p className="text-text-muted mb-4 text-sm">
+                  Spell Coven is open source. Contribute or star us on GitHub!
+                </p>
+                <a
+                  href="https://github.com/FrimJo/spell-coven-mono"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="border-surface-3 bg-surface-1/50 text-text-secondary hover:bg-surface-2 hover:text-text-primary inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors"
+                >
+                  <Github className="h-4 w-4" />
+                  View on GitHub
+                </a>
               </div>
 
               {supportUrl && (


### PR DESCRIPTION
Add GitHub links to the landing page header (desktop and mobile) and footer because the project is open source.

---
<a href="https://cursor.com/background-agent?bcId=bc-e791e2f9-2168-40a3-ab36-8bdfe728ae74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e791e2f9-2168-40a3-ab36-8bdfe728ae74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

