### PR TITLE
Fix Convex auth env generator usage in CI

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -31,6 +31,38 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 
+      - name: Start Convex backend
+        run: |
+          bun run convex:test > /tmp/convex.log 2>&1 &
+          echo $! > /tmp/convex.pid
+        working-directory: .
+
+      - name: Wait for Convex backend
+        run: |
+          for i in {1..30}; do
+            if nc -z 127.0.0.1 3210; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Convex backend failed to start" >&2
+          exit 1
+        working-directory: .
+
+      - name: Configure Convex env for e2e
+        run: |
+          AUTH_ENV=$(node scripts/generate-convex-auth-env.cjs)
+          printf '%s\n' "$AUTH_ENV" >> "$GITHUB_ENV"
+          while IFS= read -r line; do
+            export "$line"
+          done <<< "$AUTH_ENV"
+
+          CONVEX_URL="${SITE_URL}" bunx convex env set SITE_URL "${SITE_URL}" --local
+          CONVEX_URL="${SITE_URL}" bunx convex env set JWT_PRIVATE_KEY "${JWT_PRIVATE_KEY}" --local
+          CONVEX_URL="${SITE_URL}" bunx convex env set JWKS "${JWKS}" --local
+          CONVEX_URL="${SITE_URL}" bunx convex env set CONVEX_AUTH_TEST_MODE "true" --local
+        working-directory: .
+
       - name: Run E2E tests
         run: bun run e2e
         env:

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,9 +1,4 @@
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'url'
 import { defineConfig, devices } from '@playwright/test'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
 
 export default defineConfig({
   testDir: 'tests',
@@ -54,16 +49,6 @@ export default defineConfig({
     },
   ],
   webServer: [
-    {
-      command: 'bun run convex:test',
-      cwd: resolve(__dirname, '../..'),
-      url: 'http://127.0.0.1:3210',
-      timeout: process.env.CI ? 120_000 : 90_000,
-      reuseExistingServer: !process.env.CI,
-      stdout: 'pipe',
-      stderr: 'pipe',
-      ignoreHTTPSErrors: true,
-    },
     {
       command: 'bun run dev:test',
       url: 'https://localhost:1234',

--- a/scripts/generate-convex-auth-env.cjs
+++ b/scripts/generate-convex-auth-env.cjs
@@ -1,0 +1,27 @@
+const { generateKeyPairSync } = require('crypto')
+
+const siteUrl = 'http://127.0.0.1:3210'
+const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+})
+const kid = 'convex-e2e'
+const privateJwk = privateKey.export({ format: 'jwk' })
+const publicJwk = publicKey.export({ format: 'jwk' })
+const withMeta = (jwk, keyOps) => ({
+  ...jwk,
+  use: 'sig',
+  alg: 'RS256',
+  kid,
+  key_ops: keyOps,
+})
+const jwtPrivateKey = JSON.stringify(withMeta(privateJwk, ['sign']))
+const jwks = JSON.stringify({ keys: [withMeta(publicJwk, ['verify'])] })
+
+const lines = [
+  `SITE_URL=${siteUrl}`,
+  `JWT_PRIVATE_KEY=${jwtPrivateKey}`,
+  `JWKS=${jwks}`,
+  'CONVEX_AUTH_TEST_MODE=true',
+]
+
+process.stdout.write(lines.join('\n'))


### PR DESCRIPTION
### Motivation
- Ensure the Convex auth env generator runs under Node without requiring ESM by using a CommonJS script.
- Conform to Convex/JWK expectations by including `key_ops` metadata on generated JWKs so the auth keys are usable by Convex.
- Make the CI workflow reliably configure the Convex environment before tests by starting and waiting for the local Convex backend and exporting generated auth env vars.

### Description
- Add `scripts/generate-convex-auth-env.cjs`, a CommonJS generator that creates an RSA keypair and emits `SITE_URL`, `JWT_PRIVATE_KEY`, `JWKS`, and `CONVEX_AUTH_TEST_MODE=true` with `key_ops` and other JWK metadata.
- Update `.github/workflows/web-e2e.yml` to call `node scripts/generate-convex-auth-env.cjs`, append its output to `GITHUB_ENV`, export those lines into the job shell, and persist the values into Convex using `bunx convex env set` for `SITE_URL`, `JWT_PRIVATE_KEY`, `JWKS`, and `CONVEX_AUTH_TEST_MODE`.
- Start the Convex backend earlier in the job and wait for `127.0.0.1:3210` to be reachable before configuring env and running E2E tests.
- Remove the inline ESM-style generator and update `apps/web/playwright.config.ts` to avoid Playwright starting the Convex backend so the CI job controls backend lifecycle.

### Testing
- No automated tests were executed for these changes since they are CI/workflow and helper-script updates. 
- Validation will occur when the `Web E2E` CI job runs and exercises the Convex startup, env propagation, and end-to-end tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868f2885948326b72c8a7f0e2e3376)