### PR TITLE
Add React Doctor to preflight with 100/100 enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Instructions
+
+## Required pre-wrap checks
+
+- Run `bun run react:doctor` before wrapping up any implementation work.
+- A task is not considered complete unless React Doctor reports a score of `100/100`.
+
+## React Doctor LLM Skill
+
+- Use the React Doctor LLM skill workflow from the official docs when diagnosing and fixing React issues: https://github.com/millionco/react-doctor
+- Apply the suggested fixes, then rerun `bun run react:doctor` until the score reaches `100/100`.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format": "bunx turbo run format --continue -- --cache --cache-location .cache/.prettiercache",
     "format:fix": "bunx turbo run format -- --write",
     "typecheck": "bunx turbo run typecheck",
-    "preflight": "bunx turbo run typecheck && bunx turbo run lint && bunx turbo run format"
+    "react:doctor": "node ./scripts/react-doctor-preflight.mjs",
+    "preflight": "bunx turbo run typecheck && bunx turbo run lint && bunx turbo run format && bun run react:doctor"
   },
   "devDependencies": {
     "@auth/core": "^0.37.0",

--- a/scripts/react-doctor-preflight.mjs
+++ b/scripts/react-doctor-preflight.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const command = 'bunx';
+const args = ['react-doctor'];
+
+const result = spawnSync(command, args, {
+  cwd: process.cwd(),
+  stdio: 'pipe',
+  encoding: 'utf8',
+});
+
+const stdout = result.stdout ?? '';
+const stderr = result.stderr ?? '';
+
+if (stdout) process.stdout.write(stdout);
+if (stderr) process.stderr.write(stderr);
+
+if (result.error) {
+  console.error(`Failed to run React Doctor: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (typeof result.status === 'number' && result.status !== 0) {
+  process.exit(result.status);
+}
+
+const scoreMatch = stdout.match(/(?:score|health)\D{0,20}(100|\d{1,2})(?:\s*\/\s*100|%|\b)/i) ?? stdout.match(/\b(100|\d{1,2})\s*\/\s*100\b/);
+
+if (!scoreMatch) {
+  console.error('React Doctor completed, but no score was detected in the output.');
+  process.exit(1);
+}
+
+const score = Number.parseInt(scoreMatch[1], 10);
+
+if (!Number.isFinite(score)) {
+  console.error('React Doctor score could not be parsed.');
+  process.exit(1);
+}
+
+if (score < 100) {
+  console.error(`React Doctor score ${score}/100 is below the required threshold of 100/100.`);
+  process.exit(1);
+}
+
+console.log('React Doctor score is 100/100.');


### PR DESCRIPTION
### Motivation

- Enforce an automated React quality gate as part of the repository `preflight` checks to ensure code meets a strict diagnostics threshold. 
- Provide explicit agent guidance to run the React Doctor LLM workflow when diagnosing and fixing React issues so fixes are reproducible. 

### Description

- Add a new `react:doctor` npm script that runs a repository-local wrapper at `scripts/react-doctor-preflight.mjs` by calling `node ./scripts/react-doctor-preflight.mjs`. 
- Update `preflight` in `package.json` to include `bun run react:doctor` after typecheck/lint/format so the doctor is required for preflight completion. 
- Add `scripts/react-doctor-preflight.mjs` which executes `bunx react-doctor`, streams output, parses the reported score, and exits non-zero unless the score is exactly `100/100`. 
- Create `AGENTS.md` with instructions to run `bun run react:doctor` before wrapping work and to use the React Doctor LLM skill workflow from the official docs. 

### Testing

- Ran `bun run react:doctor` to validate the new gate, but the run failed because the environment cannot fetch `react-doctor` from the npm registry (HTTP 403), so the doctor could not produce a diagnostics score. 
- No other automated tests were modified or executed as part of this change, and the commit containing these files was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2d9633808326bd47f6fc0b0b957d)